### PR TITLE
infra: test-fast policies, span propagation, git2 helpers

### DIFF
--- a/tests/integration/cli/critical_path.rs
+++ b/tests/integration/cli/critical_path.rs
@@ -10,6 +10,11 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use crate::fixtures::daemon_runtime::shutdown_daemon;
+#[cfg(feature = "slow-tests")]
+use crate::fixtures::git::init_repo;
+use crate::fixtures::git::{init_bare_repo, init_repo_with_origin, repo_has_branch};
+#[cfg(feature = "slow-tests")]
+use crate::fixtures::store_lock::unlock_store;
 use assert_cmd::Command;
 use predicates::prelude::*;
 use tempfile::TempDir;


### PR DESCRIPTION
## Summary
- Introduce test-fast config overrides and shorter sync/git backoffs; add policy enums for test flags and apply them in coord.
- Add admin checkpoint wait IPC and use it in repl_e2e; keep init daemon running and reload replication.
- Propagate spans through daemon/repl threads and add CLI command span + mapping.
- Add git2 test repo helpers across fixtures and gate slow-tests helper import.

## Testing
- Not run (stacked PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds comprehensive end-to-end coverage for the `bd` CLI.
> 
> - New `tests/integration/cli/critical_path.rs` exercising init → create → list → show → close plus deps, epics, labels, comments, search, filters, sorting, limits, status, count, and setup integrations
> - Robustness scenarios for invalid IDs/transitions, duplicates, long inputs, unicode, dependency cycles, and operations on deleted/blocked items
> - Crash-recovery test verifying WAL replay and remote sync after daemon kill
> - Uses git test fixtures (`init_bare_repo`, `init_repo_with_origin`, `repo_has_branch`) and gates many tests behind `#[cfg(feature = "slow-tests")]`
> - Shared helpers for runtime/data dirs, daemon IPC, store unlock, and environment setup for deterministic runs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 319214edf3d948c915028276d24c2b90122f4683. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->