### PR TITLE
chore(git): clarify checkpoint meta names

### DIFF
--- a/crates/beads-rs/src/git/checkpoint/publish.rs
+++ b/crates/beads-rs/src/git/checkpoint/publish.rs
@@ -134,9 +134,17 @@ pub fn publish_checkpoint_with_retry(
             }
             Err(CheckpointPublishError::NonFastForward) => {
                 retries += 1;
-                tracing::debug!(retries, checkpoint_ref, "checkpoint publish retry: non-fast-forward");
+                tracing::debug!(
+                    retries,
+                    checkpoint_ref,
+                    "checkpoint publish retry: non-fast-forward"
+                );
                 if retries > max_retries {
-                    tracing::warn!(retries, checkpoint_ref, "checkpoint publish retry limit exceeded");
+                    tracing::warn!(
+                        retries,
+                        checkpoint_ref,
+                        "checkpoint publish retry limit exceeded"
+                    );
                     return Err(CheckpointPublishError::TooManyRetries { retries });
                 }
 
@@ -484,9 +492,17 @@ fn publish_store_meta_with_retry(
             Ok(()) => return Ok(commit_oid),
             Err(CheckpointPublishError::NonFastForward) => {
                 retries += 1;
-                tracing::debug!(retries, ref_name = STORE_META_REF, "store meta publish retry: non-fast-forward");
+                tracing::debug!(
+                    retries,
+                    ref_name = STORE_META_REF,
+                    "store meta publish retry: non-fast-forward"
+                );
                 if retries > max_retries {
-                    tracing::warn!(retries, ref_name = STORE_META_REF, "store meta publish retry limit exceeded");
+                    tracing::warn!(
+                        retries,
+                        ref_name = STORE_META_REF,
+                        "store meta publish retry limit exceeded"
+                    );
                     return Err(CheckpointPublishError::TooManyRetries { retries });
                 }
 
@@ -525,44 +541,44 @@ fn ensure_checkpoint_compatible(
     local: &CheckpointExport,
     remote: &CheckpointExport,
 ) -> Result<(), CheckpointPublishError> {
-    let l = &local.meta;
-    let r = &remote.meta;
+    let local_meta = &local.meta;
+    let remote_meta = &remote.meta;
 
-    if l.checkpoint_format_version != r.checkpoint_format_version {
+    if local_meta.checkpoint_format_version != remote_meta.checkpoint_format_version {
         return Err(CheckpointPublishError::IncompatibleRemote {
             reason: "checkpoint_format_version mismatch".to_string(),
         });
     }
-    if l.store_id != r.store_id {
+    if local_meta.store_id != remote_meta.store_id {
         return Err(CheckpointPublishError::IncompatibleRemote {
             reason: "store_id mismatch".to_string(),
         });
     }
-    if l.store_epoch != r.store_epoch {
+    if local_meta.store_epoch != remote_meta.store_epoch {
         return Err(CheckpointPublishError::IncompatibleRemote {
             reason: "store_epoch mismatch".to_string(),
         });
     }
-    if l.checkpoint_group != r.checkpoint_group {
+    if local_meta.checkpoint_group != remote_meta.checkpoint_group {
         return Err(CheckpointPublishError::IncompatibleRemote {
             reason: "checkpoint_group mismatch".to_string(),
         });
     }
-    if l.policy_hash != r.policy_hash {
+    if local_meta.policy_hash != remote_meta.policy_hash {
         return Err(CheckpointPublishError::IncompatibleRemote {
             reason: "policy_hash mismatch".to_string(),
         });
     }
-    if l.roster_hash != r.roster_hash {
+    if local_meta.roster_hash != remote_meta.roster_hash {
         return Err(CheckpointPublishError::IncompatibleRemote {
             reason: "roster_hash mismatch".to_string(),
         });
     }
 
-    let mut ln = l.namespaces.clone();
+    let mut ln = local_meta.namespaces.clone();
     ln.sort();
     ln.dedup();
-    let mut rn = r.namespaces.clone();
+    let mut rn = remote_meta.namespaces.clone();
     rn.sort();
     rn.dedup();
     if ln != rn {


### PR DESCRIPTION
### Motivation
- Improve readability and reduce ambiguity in checkpoint compatibility checks by using explicit names for the local and remote checkpoint metadata.
- Keep logging formatting consistent with `rustfmt` expectations.

### Description
- Replaced short locals `l`/`r` with `local_meta`/`remote_meta` in `ensure_checkpoint_compatible` in `crates/beads-rs/src/git/checkpoint/publish.rs` and updated all comparisons to use the new names.
- Updated namespace list handling to operate on `local_meta.namespaces` / `remote_meta.namespaces`.
- Applied `rustfmt`-driven formatting adjustments to nearby `tracing::debug!` / `tracing::warn!` calls for consistent formatting.

### Testing
- Ran `cargo fmt --all` and formatting is up-to-date; command succeeded.
- Ran `cargo clippy -- -D warnings` and no lints were reported; command succeeded.
- Ran `cargo test` (unit + integration suites) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976af61dbd0832e85e100e0b8cd5f1d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on readability and consistency in checkpoint publishing code.
> 
> - Rename `l`/`r` to `local_meta`/`remote_meta` in `ensure_checkpoint_compatible`, updating all field checks and namespace handling
> - Reformat `tracing::debug!`/`tracing::warn!` invocations for non-fast-forward retries to multi-line, rustfmt-consistent style
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d1ea8562f3e68a8285a85397419747125d64287. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->