### PR TITLE
chore(daemon): clarify negotiated protocol version

### DIFF
--- a/crates/beads-rs/src/daemon/repl/session.rs
+++ b/crates/beads-rs/src/daemon/repl/session.rs
@@ -901,10 +901,10 @@ fn negotiate_version(
     peer_max: u32,
     peer_min: u32,
 ) -> Result<u32, ProtocolIncompatible> {
-    let v = local.max.min(peer_max);
+    let negotiated_version = local.max.min(peer_max);
     let min_ok = local.min.max(peer_min);
-    if v >= min_ok {
-        Ok(v)
+    if negotiated_version >= min_ok {
+        Ok(negotiated_version)
     } else {
         Err(ProtocolIncompatible {
             local_min: local.min,


### PR DESCRIPTION
### Motivation
- Improve clarity in `negotiate_version` by using a descriptive variable name for the computed protocol version to make the intent of the comparison and return value obvious.

### Description
- Rename local variable `v` to `negotiated_version` in `negotiate_version` and update the comparison and `Ok(...)` return to use `negotiated_version` in `crates/beads-rs/src/daemon/repl/session.rs`.

### Testing
- Ran `cargo fmt --all`, `cargo check`, `cargo clippy -- -D warnings`, and `cargo test`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976af63139c832ea4d0039852e31468)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves readability in the replication session handshake logic.
> 
> - Rename `v` to `negotiated_version` in `negotiate_version` within `session.rs`, updating the comparison and return to use the clearer name
> 
> No behavioral changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67b2b59712db025f3fcc5061bf0e05988a2c5f63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->