### PR TITLE
chore(daemon): rename bytes read variables in frame reader

### DIFF
--- a/crates/beads-rs/src/daemon/wal/frame.rs
+++ b/crates/beads-rs/src/daemon/wal/frame.rs
@@ -30,14 +30,14 @@ impl<R: Read> FrameReader<R> {
         let mut header = [0u8; FRAME_HEADER_LEN];
         let mut read = 0usize;
         while read < header.len() {
-            let n = self
+            let bytes_read = self
                 .reader
                 .read(&mut header[read..])
                 .map_err(|source| EventWalError::Io { path: None, source })?;
-            if n == 0 {
+            if bytes_read == 0 {
                 return Ok(None);
             }
-            read += n;
+            read += bytes_read;
         }
 
         let magic = u32::from_le_bytes([header[0], header[1], header[2], header[3]]);
@@ -62,14 +62,14 @@ impl<R: Read> FrameReader<R> {
         let mut body = vec![0u8; length];
         let mut read_body = 0usize;
         while read_body < length {
-            let n = self
+            let bytes_read = self
                 .reader
                 .read(&mut body[read_body..])
                 .map_err(|source| EventWalError::Io { path: None, source })?;
-            if n == 0 {
+            if bytes_read == 0 {
                 return Ok(None);
             }
-            read_body += n;
+            read_body += bytes_read;
         }
 
         let actual_crc = crc32c(&body);


### PR DESCRIPTION
### Motivation
- Rename the ambiguous temporary `n` variable in `FrameReader::read_next` to `bytes_read` to improve clarity in the header and body read loops.

### Description
- Updated the two read loops in `crates/beads-rs/src/daemon/wal/frame.rs` to use `bytes_read` for the `read == 0` EOF checks and for incrementing the running counters.

### Testing
- Ran `cargo fmt --all`, `cargo clippy -- -D warnings`, and `cargo test`, and all checks and tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976af8f0c1c832ea0ecacab4c015664)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Minor readability improvement in WAL frame reader.
> 
> - In `crates/beads-rs/src/daemon/wal/frame.rs`, `FrameReader::read_next` now uses `bytes_read` instead of `n` in both header and body read loops for EOF checks and counters.
> 
> No logic or behavior changes; tests remain the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff854bdb583f11d821f8cafe28c21f907c2bde6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->