### PR TITLE
chore(core): clarify normalize_cycle identifier

### DIFF
--- a/crates/beads-rs/src/core/state.rs
+++ b/crates/beads-rs/src/core/state.rs
@@ -1461,12 +1461,12 @@ impl CanonicalState {
             let mut best = 0;
             for i in 1..n {
                 let a = base[i].as_str();
-                let b = base[best].as_str();
-                if a < b {
+                let best_id_str = base[best].as_str();
+                if a < best_id_str {
                     best = i;
                     continue;
                 }
-                if a == b {
+                if a == best_id_str {
                     for offset in 1..n {
                         let lhs = base[(i + offset) % n].as_str();
                         let rhs = base[(best + offset) % n].as_str();


### PR DESCRIPTION
### Motivation
- Improve readability in `normalize_cycle` by using a clearer name for the best-index string to avoid ambiguity in comparisons.

### Description
- Rename temporary variable from `b` to `best_id_str` in `crates/beads-rs/src/core/state.rs` and update the immediate comparisons to use the new identifier.

### Testing
- Ran `cargo fmt --all`, `cargo clippy -- -D warnings`, and `cargo test`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976afac36a4832e86bb9ff14a93f12a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors a local variable in `normalize_cycle` for readability and to avoid redundant calls.
> 
> - Renames `b` to `best_id_str` and updates adjacent comparisons to use the new identifier
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e49f41c0ce4bbd3125956b921a4d91bd222c81c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->