### PR TITLE
chore(core): clarify normalize_cycle variable name

### DIFF
--- a/crates/beads-rs/src/core/state.rs
+++ b/crates/beads-rs/src/core/state.rs
@@ -1460,13 +1460,13 @@ impl CanonicalState {
             let n = base.len();
             let mut best = 0;
             for i in 1..n {
-                let a = base[i].as_str();
+                let candidate_id_str = base[i].as_str();
                 let b = base[best].as_str();
-                if a < b {
+                if candidate_id_str < b {
                     best = i;
                     continue;
                 }
-                if a == b {
+                if candidate_id_str == b {
                     for offset in 1..n {
                         let lhs = base[(i + offset) % n].as_str();
                         let rhs = base[(best + offset) % n].as_str();


### PR DESCRIPTION
### Motivation
- Improve readability by giving a descriptive name to the loop-local string used when comparing bead ids in `normalize_cycle`.

### Description
- Rename `let a = base[i].as_str();` to `let candidate_id_str = base[i].as_str();` and update subsequent comparisons in `crates/beads-rs/src/core/state.rs` to use the new name.

### Testing
- Ran `cargo fmt --all`, `cargo check`, `cargo clippy -- -D warnings`, and `cargo test`, and all succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976afacb350832eb7e4d40ea573573d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves readability in dependency cycle normalization.
> 
> - In `state.rs` `normalize_cycle`, renames `a` to `candidate_id_str` and updates string comparisons accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44d289a52e3dd1e57f6158cb1a268e15bc73e3b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->