### PR TITLE
chore: fix clippy warnings (bd-8joz)

### DIFF
--- a/crates/beads-rs/src/cli/commands/epic.rs
+++ b/crates/beads-rs/src/cli/commands/epic.rs
@@ -132,11 +132,11 @@ pub(crate) fn render_epic_statuses(statuses: &[crate::api::EpicStatus]) -> Strin
 
     let mut out = String::new();
     for s in statuses {
-        let pct = if s.total_children > 0 {
-            (s.closed_children * 100) / s.total_children
-        } else {
-            0
-        };
+        let pct = s
+            .closed_children
+            .saturating_mul(100)
+            .checked_div(s.total_children)
+            .unwrap_or(0);
         let icon = if s.eligible_for_close { "✓" } else { "○" };
         out.push_str(&format!(
             "{icon} {} {}\n",

--- a/crates/beads-rs/src/cli/commands/show.rs
+++ b/crates/beads-rs/src/cli/commands/show.rs
@@ -348,25 +348,22 @@ fn render_epic_children(out: &mut String, children: &[IssueSummary]) {
     }
 
     // Sort remaining by priority (P0 first), then by status (in_progress before open)
-    remaining.sort_by(|a, b| {
-        a.priority.cmp(&b.priority).then_with(|| {
-            // in_progress before open
-            let a_prog = a.status == "in_progress";
-            let b_prog = b.status == "in_progress";
-            b_prog.cmp(&a_prog)
-        })
+    remaining.sort_by_key(|child| {
+        (
+            child.priority,
+            std::cmp::Reverse(child.status == "in_progress"),
+        )
     });
 
     // Sort done by updated_at (most recent first)
-    done.sort_by(|a, b| b.updated_at.wall_ms.cmp(&a.updated_at.wall_ms));
+    done.sort_by_key(|child| std::cmp::Reverse(child.updated_at.wall_ms));
 
     let total = children.len();
     let done_count = done.len();
-    let pct = if total > 0 {
-        (done_count * 100) / total
-    } else {
-        0
-    };
+    let pct = done_count
+        .saturating_mul(100)
+        .checked_div(total)
+        .unwrap_or(0);
 
     out.push_str(&format!(
         "\nProgress: {}/{} done ({}%)\n",

--- a/crates/beads-rs/src/daemon/admin.rs
+++ b/crates/beads-rs/src/daemon/admin.rs
@@ -626,11 +626,7 @@ fn build_wal_status(
         let mut segments = reader
             .list_segments(namespace)
             .map_err(|err| OpError::StoreRuntime(Box::new(StoreRuntimeError::WalIndex(err))))?;
-        segments.sort_by(|a, b| {
-            a.created_at_ms
-                .cmp(&b.created_at_ms)
-                .then_with(|| a.segment_id.cmp(&b.segment_id))
-        });
+        segments.sort_by_key(|segment| (segment.created_at_ms, segment.segment_id));
         let mut segment_infos = Vec::new();
         let mut segment_stats = Vec::new();
         let mut total_bytes = 0u64;
@@ -851,7 +847,7 @@ fn build_replica_liveness(
         }
     };
 
-    rows.sort_by(|a, b| a.replica_id.cmp(&b.replica_id));
+    rows.sort_by_key(|row| row.replica_id);
     rows.into_iter()
         .map(|row| AdminReplicaLiveness {
             replica_id: row.replica_id,

--- a/crates/beads-rs/src/daemon/wal/memory_index.rs
+++ b/crates/beads-rs/src/daemon/wal/memory_index.rs
@@ -408,11 +408,7 @@ impl WalIndexReader for MemoryWalIndexReader {
                 .filter(|row| &row.namespace == ns)
                 .cloned()
                 .collect();
-            rows.sort_by(|a, b| {
-                a.created_at_ms
-                    .cmp(&b.created_at_ms)
-                    .then_with(|| a.segment_id.cmp(&b.segment_id))
-            });
+            rows.sort_by_key(|row| (row.created_at_ms, row.segment_id));
             Ok(rows)
         })
     }
@@ -420,11 +416,7 @@ impl WalIndexReader for MemoryWalIndexReader {
     fn load_watermarks(&self) -> Result<Vec<WatermarkRow>, WalIndexError> {
         self.with_state(|state| {
             let mut rows: Vec<WatermarkRow> = state.watermarks.values().cloned().collect();
-            rows.sort_by(|a, b| {
-                a.namespace
-                    .cmp(&b.namespace)
-                    .then_with(|| a.origin.cmp(&b.origin))
-            });
+            rows.sort_by_key(|row| (row.namespace.clone(), row.origin));
             Ok(rows)
         })
     }
@@ -432,7 +424,7 @@ impl WalIndexReader for MemoryWalIndexReader {
     fn load_hlc(&self) -> Result<Vec<HlcRow>, WalIndexError> {
         self.with_state(|state| {
             let mut rows: Vec<HlcRow> = state.hlc.values().cloned().collect();
-            rows.sort_by(|a, b| a.actor_id.cmp(&b.actor_id));
+            rows.sort_by_key(|row| row.actor_id.clone());
             Ok(rows)
         })
     }
@@ -441,7 +433,7 @@ impl WalIndexReader for MemoryWalIndexReader {
         self.with_state(|state| {
             let mut rows: Vec<ReplicaLivenessRow> =
                 state.replica_liveness.values().cloned().collect();
-            rows.sort_by(|a, b| a.replica_id.cmp(&b.replica_id));
+            rows.sort_by_key(|row| row.replica_id);
             Ok(rows)
         })
     }

--- a/crates/beads-rs/src/git/checkpoint/cache.rs
+++ b/crates/beads-rs/src/git/checkpoint/cache.rs
@@ -323,7 +323,7 @@ fn prune_old_entries(
         });
     }
 
-    entries.sort_by(|a, b| b.created_at_ms.cmp(&a.created_at_ms));
+    entries.sort_by_key(|entry| std::cmp::Reverse(entry.created_at_ms));
 
     let mut keep: HashSet<String> = HashSet::new();
     keep.insert(keep_checkpoint_id.to_string());


### PR DESCRIPTION
## Summary
- replace manual division with checked division in epic/show rendering
- use sort_by_key/reverse key sorts to satisfy clippy

## Testing
- cargo clippy -p beads-rs -- -D warnings

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/delightful-ai/beads-rs/pull/24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves safety and code clarity while resolving clippy warnings.
> 
> - Replaces manual percentage math with `saturating_mul(...).checked_div(...).unwrap_or(0)` in `epic.rs` and `show.rs` to avoid overflow and division-by-zero
> - Refactors multiple custom comparators to `sort_by_key` (with `std::cmp::Reverse` where needed) across CLI rendering, admin WAL/replica liveness, in-memory WAL index, and checkpoint cache pruning
> - Minor ordering cleanups maintain intended sort order (e.g., by created time/id, priority/status, updated time)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3403f35ae7b23664214efd1238800a8344192800. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->