### PR TITLE
🧪 [Bead] Add content hash integrity test for BeadCore fields

### DIFF
--- a/crates/beads-core/src/bead.rs
+++ b/crates/beads-core/src/bead.rs
@@ -460,10 +460,7 @@ impl MutateForTest for Stamp {
     fn mutate_for_test(&mut self) {
         // Increment time
         let new_time = self.at.wall_ms + 1;
-        *self = Stamp::new(
-            WriteStamp::new(new_time, self.at.counter),
-            self.by.clone(),
-        );
+        *self = Stamp::new(WriteStamp::new(new_time, self.at.counter), self.by.clone());
     }
 }
 


### PR DESCRIPTION
Added a regression test `content_hash_depends_on_core_fields` to `crates/beads-core/src/bead.rs` that ensures `compute_content_hash` depends on all fields of `BeadCore`.
This required implementing `MutateForTest` for `BeadId`, `Stamp`, `BranchName`, `Creation`, and `BeadCore` to allow test-only mutation of these otherwise immutable types.
This addresses a violation of the "Test Design" philosophy by ensuring that the critical integrity function `compute_content_hash` is verified against all fields of the target structure.

---
*PR created automatically by Jules for task [13995155171545200052](https://jules.google.com/task/13995155171545200052) started by @darinkishore*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/delightful-ai/beads-rs/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are test-only (`#[cfg(test)]`) helpers and a new regression test, with no production logic modifications. Potential risk is limited to added test maintenance/fragility if core fields evolve.
> 
> **Overview**
> Adds a new regression test `content_hash_depends_on_core_fields` to ensure `compute_content_hash` changes whenever any `BeadCore` field changes.
> 
> Introduces test-only mutation utilities for core/identity types (`BeadCore::field_names`/`mutate_field` plus `MutateForTest` impls for `BeadId`, `Stamp`, `BranchName`, `Creation`, and `BeadCore`) to support systematic field mutation in the hash integrity tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ddb83a1275a3017eff04de79f159b20ed5ef779. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->