### PR TITLE
🧪 [Add tests for Tombstone::join]

### DIFF
--- a/crates/beads-core/src/tombstone.rs
+++ b/crates/beads-core/src/tombstone.rs
@@ -91,3 +91,154 @@ impl Tombstone {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::identity::ActorId;
+    use crate::time::WriteStamp;
+    use proptest::prelude::*;
+
+    fn make_stamp(wall_ms: u64, counter: u32, actor: &str) -> Stamp {
+        Stamp::new(
+            WriteStamp::new(wall_ms, counter),
+            ActorId::new(actor).unwrap(),
+        )
+    }
+
+    fn bead_id(id: &str) -> BeadId {
+        BeadId::parse(id).unwrap()
+    }
+
+    #[test]
+    fn test_join_keeps_later_deletion() {
+        let id = bead_id("bd-test");
+        let stamp1 = make_stamp(1000, 0, "alice");
+        let stamp2 = make_stamp(2000, 0, "alice");
+
+        let t1 = Tombstone::new(id.clone(), stamp1, None);
+        let t2 = Tombstone::new(id.clone(), stamp2, None);
+
+        let merged = Tombstone::join(&t1, &t2);
+        assert_eq!(merged.deleted.at.wall_ms, 2000);
+
+        // Commutativity check for distinct stamps
+        let merged_rev = Tombstone::join(&t2, &t1);
+        assert_eq!(merged_rev.deleted.at.wall_ms, 2000);
+    }
+
+    #[test]
+    fn test_join_same_stamp_left_wins() {
+        let id = bead_id("bd-test");
+        let stamp = make_stamp(1000, 0, "alice");
+
+        let t1 = Tombstone::new(id.clone(), stamp.clone(), Some("reason A".to_string()));
+        let t2 = Tombstone::new(id.clone(), stamp.clone(), Some("reason B".to_string()));
+
+        let merged = Tombstone::join(&t1, &t2);
+        assert_eq!(merged.reason.as_deref(), Some("reason A"));
+
+        let merged_rev = Tombstone::join(&t2, &t1);
+        assert_eq!(merged_rev.reason.as_deref(), Some("reason B"));
+    }
+
+    #[test]
+    #[should_panic(expected = "join requires same id")]
+    fn test_join_different_id_panics() {
+        let t1 = Tombstone::new(bead_id("bd-a"), make_stamp(1000, 0, "alice"), None);
+        let t2 = Tombstone::new(bead_id("bd-b"), make_stamp(2000, 0, "bob"), None);
+        Tombstone::join(&t1, &t2);
+    }
+
+    #[test]
+    #[should_panic(expected = "join requires same lineage")]
+    fn test_join_different_lineage_panics() {
+        let id = bead_id("bd-test");
+        let stamp = make_stamp(1000, 0, "alice");
+
+        let t1 = Tombstone::new(id.clone(), stamp.clone(), None);
+        let t2 = Tombstone::new_collision(
+            id.clone(),
+            stamp.clone(),
+            make_stamp(500, 0, "bob"), // lineage
+            None,
+        );
+        Tombstone::join(&t1, &t2);
+    }
+
+    fn stamp_strategy() -> impl Strategy<Value = Stamp> {
+        let actor = prop_oneof![Just("alice"), Just("bob"), Just("carol")];
+        (0u64..10000, 0u32..10, actor).prop_map(|(wall_ms, counter, actor)| {
+            Stamp::new(
+                WriteStamp::new(wall_ms, counter),
+                ActorId::new(actor).unwrap(),
+            )
+        })
+    }
+
+    fn tombstone_strategy() -> impl Strategy<Value = Tombstone> {
+        (
+            Just("bd-prop-test"),
+            stamp_strategy(),
+            prop::option::of(any::<String>()),
+            prop::option::of(stamp_strategy()),
+        )
+            .prop_map(|(id_str, deleted, reason, lineage)| {
+                let id = BeadId::parse(id_str).unwrap();
+                if let Some(l) = lineage {
+                    Tombstone::new_collision(id, deleted, l, reason)
+                } else {
+                    Tombstone::new(id, deleted, reason)
+                }
+            })
+    }
+
+    proptest! {
+        #[test]
+        fn prop_join_commutative_with_distinct_stamps(
+            t1 in tombstone_strategy(),
+            mut t2 in tombstone_strategy()
+        ) {
+            // Ensure same ID and lineage for valid join
+            t2.id = t1.id.clone();
+            t2.lineage = t1.lineage.clone();
+
+            // Ensure distinct deleted stamps to guarantee commutativity
+            if t1.deleted == t2.deleted {
+                // If stamps equal, modify one to be different
+                t2.deleted.at.counter += 1;
+            }
+
+            let m1 = Tombstone::join(&t1, &t2);
+            let m2 = Tombstone::join(&t2, &t1);
+
+            assert_eq!(m1, m2);
+            assert!(m1.deleted >= t1.deleted);
+            assert!(m1.deleted >= t2.deleted);
+        }
+
+        #[test]
+        fn prop_join_idempotent(t in tombstone_strategy()) {
+            let merged = Tombstone::join(&t, &t);
+            assert_eq!(merged, t);
+        }
+
+        #[test]
+        fn prop_join_associative(
+            t1 in tombstone_strategy(),
+            mut t2 in tombstone_strategy(),
+            mut t3 in tombstone_strategy()
+        ) {
+            // Ensure same ID and lineage
+            t2.id = t1.id.clone();
+            t2.lineage = t1.lineage.clone();
+            t3.id = t1.id.clone();
+            t3.lineage = t1.lineage.clone();
+
+            let m1 = Tombstone::join(&Tombstone::join(&t1, &t2), &t3);
+            let m2 = Tombstone::join(&t1, &Tombstone::join(&t2, &t3));
+
+            assert_eq!(m1, m2);
+        }
+    }
+}


### PR DESCRIPTION
* 🎯 **What:** Added comprehensive unit and property-based tests for `Tombstone::join` in `crates/beads-core/src/tombstone.rs`.
* 📊 **Coverage:** Covered happy paths (later deletion wins), edge cases (same timestamp), and safety assertions (ID/Lineage mismatch). Verified commutativity, idempotency, and associativity using `proptest`.
* ✨ **Result:** Increased confidence in the correctness and stability of the `Tombstone` CRDT merge logic.

---
*PR created automatically by Jules for task [1080568969528314602](https://jules.google.com/task/1080568969528314602) started by @darinkishore*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/delightful-ai/beads-rs/pull/52" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production logic modifications; risk is limited to potential flakiness/compile issues in the new proptests.
> 
> **Overview**
> Adds a new `#[cfg(test)]` suite in `tombstone.rs` to validate `Tombstone::join` merge behavior.
> 
> Covers unit cases for *later deletion wins*, *tie-breaking when stamps are equal (left wins)*, and `debug_assert` invariants for mismatched `id`/`lineage`, plus property-based checks (via `proptest`) for commutativity (with distinct stamps), idempotency, and associativity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20274a0fee7e31490b6e649533c330a2d16f2db8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->