### PR TITLE
🧪 Testing: Add tests for CLI bead type parsing

### DIFF
--- a/crates/beads-cli/src/parsers.rs
+++ b/crates/beads-cli/src/parsers.rs
@@ -189,3 +189,52 @@ fn split_kind_id(raw: &str) -> Result<(Option<DepKind>, String)> {
         Ok((None, raw.trim().to_string()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_bead_type_valid() {
+        let cases = vec![
+            ("bug", BeadType::Bug),
+            ("bugs", BeadType::Bug),
+            ("BUG", BeadType::Bug),
+            ("  bug  ", BeadType::Bug),
+            ("feature", BeadType::Feature),
+            ("feat", BeadType::Feature),
+            ("features", BeadType::Feature),
+            ("task", BeadType::Task),
+            ("todo", BeadType::Task),
+            ("tasks", BeadType::Task),
+            ("epic", BeadType::Epic),
+            ("epics", BeadType::Epic),
+            ("chore", BeadType::Chore),
+            ("chores", BeadType::Chore),
+            ("maintenance", BeadType::Chore),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(
+                parse_bead_type(input).unwrap(),
+                expected,
+                "Failed to parse '{}'",
+                input
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_bead_type_invalid() {
+        let cases = vec!["invalid", "random", "", "123"];
+
+        for input in cases {
+            match parse_bead_type(input) {
+                Err(ParseError::UnknownBeadType { raw }) => {
+                    assert_eq!(raw, input.to_string());
+                }
+                _ => panic!("Expected UnknownBeadType error for '{}'", input),
+            }
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added unit tests for `parse_bead_type` in `crates/beads-cli/src/parsers.rs`.
📊 **Coverage:**
- Verified valid inputs for all `BeadType` variants (Bug, Feature, Task, Epic, Chore).
- Verified aliases (e.g., "todo" for Task, "feat" for Feature).
- Verified case insensitivity (e.g., "BUG", "Feat").
- Verified whitespace trimming.
- Verified error handling for invalid inputs.
✨ **Result:** The `parse_bead_type` function is now fully tested, ensuring reliable parsing of user input for issue types.

---
*PR created automatically by Jules for task [2198377471472916649](https://jules.google.com/task/2198377471472916649) started by @darinkishore*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/delightful-ai/beads-rs/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that doesn’t affect production code paths; main risk is only around tightening/encoding expected parsing behavior.
> 
> **Overview**
> Adds a new `#[cfg(test)]` unit test module in `crates/beads-cli/src/parsers.rs` to cover `parse_bead_type` behavior.
> 
> Tests validate parsing of all supported `BeadType` variants including aliases, case-insensitivity, and whitespace trimming, and assert that invalid inputs return `ParseError::UnknownBeadType` with the original raw string preserved.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65c1f8c65a71ac9cb207e9fe18d8ec8252bd3dc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->