### PR TITLE
🧹 [code health improvement] Remove misleading `#[allow(dead_code)]` annotations

### DIFF
--- a/crates/beads-core/src/apply.rs
+++ b/crates/beads-core/src/apply.rs
@@ -53,11 +53,9 @@ pub enum ApplyError {
 /// ```compile_fail
 /// use beads_core::{apply_event, CanonicalState, EventBody};
 ///
-/// fn main() {
-///     let mut state = CanonicalState::new();
-///     let body: EventBody = todo!();
-///     apply_event(&mut state, &body);
-/// }
+/// let mut state = CanonicalState::new();
+/// let body: EventBody = todo!();
+/// apply_event(&mut state, &body);
 /// ```
 pub fn apply_event(
     state: &mut CanonicalState,

--- a/crates/beads-rs/src/daemon/store/runtime.rs
+++ b/crates/beads-rs/src/daemon/store/runtime.rs
@@ -62,7 +62,6 @@ pub(crate) struct WalTailTruncatedRecord {
 pub struct StoreRuntime {
     pub(crate) primary_remote: RemoteUrl,
     pub(crate) meta: StoreMeta,
-    #[allow(dead_code)]
     pub(crate) policies: BTreeMap<NamespaceId, NamespacePolicy>,
     pub(crate) state: StoreState,
     pub(crate) last_wal_tail_truncated: Option<WalTailTruncatedRecord>,
@@ -74,14 +73,11 @@ pub struct StoreRuntime {
     pub(crate) broadcaster: EventBroadcaster,
     pub(crate) admission: AdmissionController,
     pub(crate) maintenance_mode: bool,
-    #[allow(dead_code)]
     pub(crate) peer_acks: Arc<Mutex<PeerAckTable>>,
     pub(crate) event_wal: EventWal,
-    #[allow(dead_code)]
     pub(crate) wal_index: Arc<dyn WalIndex>,
     pub(crate) last_wal_checkpoint: Option<Instant>,
     pub(crate) last_lock_heartbeat: Option<Instant>,
-    #[allow(dead_code)]
     lock: StoreLock,
 }
 


### PR DESCRIPTION
🎯 **What:** Removed `#[allow(dead_code)]` annotations from `policies`, `peer_acks`, `wal_index`, and `lock` fields in `StoreRuntime` struct in `crates/beads-rs/src/daemon/store/runtime.rs`. Also fixed a `clippy::needless_doctest_main` warning in `crates/beads-core/src/apply.rs`.

💡 **Why:** The `#[allow(dead_code)]` annotations were misleading because the fields are actually used in the codebase. Removing them improves code clarity and ensures that if they ever become truly unused, the compiler will warn us. The fix in `beads-core` ensures that `cargo clippy` runs cleanly across the workspace, which is essential for maintaining code health.

✅ **Verification:** Ran `cargo check -p beads-rs` and `cargo test -p beads-rs`. Confirmed no dead code warnings were generated (proving fields are used) and all tests passed. Also ran `cargo clippy -p beads-rs` which passed after the `beads-core` fix.

✨ **Result:** Cleaner code in `StoreRuntime` and a passing clippy check for `beads-rs` and `beads-core`.

---
*PR created automatically by Jules for task [4417117181442753128](https://jules.google.com/task/4417117181442753128) started by @darinkishore*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/delightful-ai/beads-rs/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure code-health changes: removes suppressions and tweaks a doctest snippet, with no functional logic changes and minimal runtime risk.
> 
> **Overview**
> Removes misleading `#[allow(dead_code)]` annotations from several `StoreRuntime` fields (`policies`, `peer_acks`, `wal_index`, `lock`) so truly-unused fields will surface as compiler warnings.
> 
> Adjusts the `apply_event` `compile_fail` doctest in `beads-core` to eliminate `clippy::needless_doctest_main` (removing the unnecessary `fn main()` wrapper) while keeping the example’s intent unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b1cf297becb69685116770af355f02d32a900e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->