### PR TITLE
🧹 Split beads-core state.rs into multiple modules

### DIFF
--- a/crates/beads-core/src/state/deps.rs
+++ b/crates/beads-core/src/state/deps.rs
@@ -1,0 +1,128 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::dep::DepKey;
+use crate::domain::DepKind;
+use crate::identity::BeadId;
+use crate::orset::{Dot, Dvv, OrSet};
+use crate::time::Stamp;
+
+use super::max_stamp;
+
+/// Canonical dependency store (OR-Set membership only).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DepStore {
+    pub(crate) set: OrSet<DepKey>,
+    pub(crate) stamp: Option<Stamp>,
+}
+
+impl DepStore {
+    pub fn new() -> Self {
+        Self {
+            set: OrSet::new(),
+            stamp: None,
+        }
+    }
+
+    pub fn from_parts(set: OrSet<DepKey>, stamp: Option<Stamp>) -> Self {
+        Self { set, stamp }
+    }
+    pub fn stamp(&self) -> Option<&Stamp> {
+        self.stamp.as_ref()
+    }
+
+    pub fn cc(&self) -> &Dvv {
+        self.set.cc()
+    }
+
+    pub fn contains(&self, key: &DepKey) -> bool {
+        self.set.contains(key)
+    }
+
+    pub fn len(&self) -> usize {
+        self.set.values().count()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.set.is_empty()
+    }
+
+    pub fn values(&self) -> impl Iterator<Item = &DepKey> {
+        self.set.values()
+    }
+
+    pub fn dots_for(&self, key: &DepKey) -> Option<&BTreeSet<Dot>> {
+        self.set.dots_for(key)
+    }
+
+    pub fn join(a: &Self, b: &Self) -> Self {
+        Self {
+            set: OrSet::join(&a.set, &b.set),
+            stamp: max_stamp(a.stamp.as_ref(), b.stamp.as_ref()),
+        }
+    }
+}
+
+impl Default for DepStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Derived indexes for efficient dependency lookups.
+///
+/// These are rebuilt from `dep_store` on load and updated incrementally.
+/// Not serialized - derived state only.
+#[derive(Default, Debug, Clone)]
+pub struct DepIndexes {
+    /// from -> [(to, kind)] for active deps
+    out_edges: BTreeMap<BeadId, Vec<(BeadId, DepKind)>>,
+    /// to -> [(from, kind)] for active deps
+    in_edges: BTreeMap<BeadId, Vec<(BeadId, DepKind)>>,
+}
+
+impl DepIndexes {
+    /// Create empty indexes.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add an edge to both indexes.
+    pub(crate) fn add(&mut self, from: &BeadId, to: &BeadId, kind: DepKind) {
+        self.out_edges
+            .entry(from.clone())
+            .or_default()
+            .push((to.clone(), kind));
+        self.in_edges
+            .entry(to.clone())
+            .or_default()
+            .push((from.clone(), kind));
+    }
+
+    /// Remove an edge from both indexes.
+    pub(crate) fn remove(&mut self, from: &BeadId, to: &BeadId, kind: DepKind) {
+        if let Some(edges) = self.out_edges.get_mut(from) {
+            edges.retain(|(t, k)| !(t == to && *k == kind));
+        }
+        if let Some(edges) = self.in_edges.get_mut(to) {
+            edges.retain(|(f, k)| !(f == from && *k == kind));
+        }
+    }
+
+    /// Get outgoing edges from a bead.
+    pub fn out_edges(&self, id: &BeadId) -> &[(BeadId, DepKind)] {
+        self.out_edges
+            .get(id)
+            .map(|v: &Vec<(BeadId, DepKind)>| v.as_slice())
+            .unwrap_or(&[])
+    }
+
+    /// Get incoming edges to a bead.
+    pub fn in_edges(&self, id: &BeadId) -> &[(BeadId, DepKind)] {
+        self.in_edges
+            .get(id)
+            .map(|v: &Vec<(BeadId, DepKind)>| v.as_slice())
+            .unwrap_or(&[])
+    }
+}

--- a/crates/beads-core/src/state/labels.rs
+++ b/crates/beads-core/src/state/labels.rs
@@ -1,0 +1,194 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::collections::{Label, Labels};
+use crate::identity::BeadId;
+use crate::orset::{Dot, Dvv, OrSet};
+use crate::time::Stamp;
+use crate::wire_bead::WireLineageStamp;
+
+use super::max_stamp;
+
+/// Label membership for a single bead.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LabelState {
+    pub(crate) set: OrSet<Label>,
+    pub(crate) stamp: Option<Stamp>,
+}
+
+impl LabelState {
+    pub fn new() -> Self {
+        Self {
+            set: OrSet::new(),
+            stamp: None,
+        }
+    }
+
+    pub fn from_parts(set: OrSet<Label>, stamp: Option<Stamp>) -> Self {
+        Self { set, stamp }
+    }
+
+    pub fn stamp(&self) -> Option<&Stamp> {
+        self.stamp.as_ref()
+    }
+
+    pub fn labels(&self) -> Labels {
+        self.set.values().cloned().collect()
+    }
+
+    pub fn values(&self) -> impl Iterator<Item = &Label> {
+        self.set.values()
+    }
+
+    pub fn dots_for(&self, label: &Label) -> Option<&BTreeSet<Dot>> {
+        self.set.dots_for(label)
+    }
+
+    pub fn cc(&self) -> &Dvv {
+        self.set.cc()
+    }
+
+    pub fn join(a: &Self, b: &Self) -> Self {
+        Self {
+            set: OrSet::join(&a.set, &b.set),
+            stamp: max_stamp(a.stamp.as_ref(), b.stamp.as_ref()),
+        }
+    }
+}
+
+impl Default for LabelState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Canonical label store keyed by bead id + lineage stamp.
+#[derive(Clone, Debug, Default)]
+pub struct LabelStore {
+    by_bead: BTreeMap<BeadId, BTreeMap<Stamp, LabelState>>,
+}
+
+impl LabelStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn state(&self, id: &BeadId, lineage: &Stamp) -> Option<&LabelState> {
+        self.by_bead.get(id).and_then(|states| states.get(lineage))
+    }
+
+    pub fn state_mut(&mut self, id: &BeadId, lineage: &Stamp) -> &mut LabelState {
+        self.by_bead
+            .entry(id.clone())
+            .or_default()
+            .entry(lineage.clone())
+            .or_default()
+    }
+
+    pub fn insert_state(&mut self, id: BeadId, lineage: Stamp, state: LabelState) {
+        self.by_bead.entry(id).or_default().insert(lineage, state);
+    }
+
+    pub(crate) fn take_state(&mut self, id: &BeadId, lineage: &Stamp) -> Option<LabelState> {
+        let lineages = self.by_bead.get_mut(id)?;
+        let state = lineages.remove(lineage)?;
+        if lineages.is_empty() {
+            self.by_bead.remove(id);
+        }
+        Some(state)
+    }
+
+    pub fn join(a: &Self, b: &Self) -> Self {
+        let mut merged = LabelStore::new();
+        let ids: BTreeSet<_> = a.by_bead.keys().chain(b.by_bead.keys()).cloned().collect();
+        for id in ids {
+            let mut merged_lineages: BTreeMap<Stamp, LabelState> = BTreeMap::new();
+            if let Some(states) = a.by_bead.get(&id) {
+                for (lineage, state) in states {
+                    merged_lineages.insert(lineage.clone(), state.clone());
+                }
+            }
+            if let Some(states) = b.by_bead.get(&id) {
+                for (lineage, state) in states {
+                    match merged_lineages.get(lineage) {
+                        Some(existing) => {
+                            merged_lineages
+                                .insert(lineage.clone(), LabelState::join(existing, state));
+                        }
+                        None => {
+                            merged_lineages.insert(lineage.clone(), state.clone());
+                        }
+                    }
+                }
+            }
+            if !merged_lineages.is_empty() {
+                merged.by_bead.insert(id.clone(), merged_lineages);
+            }
+        }
+        merged
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct LineageLabelState {
+    lineage: WireLineageStamp,
+    state: LabelState,
+}
+
+#[derive(Serialize, Deserialize)]
+struct LabelStoreWire {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    by_bead: BTreeMap<BeadId, Vec<LineageLabelState>>,
+}
+
+impl Serialize for LabelStore {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut by_bead = BTreeMap::new();
+        for (id, lineages) in &self.by_bead {
+            let entries = lineages
+                .iter()
+                .map(|(lineage, state)| LineageLabelState {
+                    lineage: WireLineageStamp::from(lineage.clone()),
+                    state: state.clone(),
+                })
+                .collect::<Vec<_>>();
+            if !entries.is_empty() {
+                by_bead.insert(id.clone(), entries);
+            }
+        }
+        let wire = LabelStoreWire { by_bead };
+        wire.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for LabelStore {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = LabelStoreWire::deserialize(deserializer)?;
+        let mut by_bead: BTreeMap<BeadId, BTreeMap<Stamp, LabelState>> = BTreeMap::new();
+        for (id, entries) in wire.by_bead {
+            let mut lineages: BTreeMap<Stamp, LabelState> = BTreeMap::new();
+            for entry in entries {
+                let lineage = entry.lineage.stamp();
+                match lineages.get(&lineage) {
+                    Some(existing) => {
+                        lineages.insert(lineage, LabelState::join(existing, &entry.state));
+                    }
+                    None => {
+                        lineages.insert(lineage, entry.state);
+                    }
+                }
+            }
+            if !lineages.is_empty() {
+                by_bead.insert(id, lineages);
+            }
+        }
+        Ok(LabelStore { by_bead })
+    }
+}

--- a/crates/beads-core/src/state/mod.rs
+++ b/crates/beads-core/src/state/mod.rs
@@ -1,0 +1,38 @@
+//! Layer 9: Canonical State
+//!
+//! The single source of truth for beads, tombstones, and deps.
+//!
+//! INVARIANT: each BeadId maps to either a live bead or a global tombstone.
+//! This is structural via BeadEntry; lineage-scoped collision tombstones are separate.
+//!
+//! Collision tombstones are lineage-scoped and may coexist with a live bead of
+//! the same ID when the live bead is a different lineage (SPEC §4.1.1).
+//!
+//! Resurrection rule: modification strictly newer than deletion can resurrect.
+
+use crate::time::Stamp;
+
+pub mod canonical;
+pub mod deps;
+pub mod labels;
+pub mod notes;
+
+pub use canonical::{
+    CanonicalState, LiveLookupError, bead_collision_cmp, bead_content_hash_for_collision,
+    legacy_fallback_lineage,
+};
+pub use deps::{DepIndexes, DepStore};
+pub use labels::{LabelState, LabelStore};
+pub use notes::{NoteStore, note_collision_cmp};
+
+pub(crate) fn max_stamp(a: Option<&Stamp>, b: Option<&Stamp>) -> Option<Stamp> {
+    match (a, b) {
+        (Some(left), Some(right)) => Some(if left >= right {
+            left.clone()
+        } else {
+            right.clone()
+        }),
+        (Some(stamp), None) | (None, Some(stamp)) => Some(stamp.clone()),
+        (None, None) => None,
+    }
+}

--- a/crates/beads-core/src/state/notes.rs
+++ b/crates/beads-core/src/state/notes.rs
@@ -1,0 +1,267 @@
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::composite::Note;
+use crate::event::sha256_bytes;
+use crate::identity::{BeadId, NoteId};
+use crate::time::Stamp;
+use crate::wire_bead::WireLineageStamp;
+
+/// Canonical note store keyed by bead id + lineage stamp.
+#[derive(Clone, Debug, Default)]
+pub struct NoteStore {
+    pub(crate) by_bead: BTreeMap<BeadId, BTreeMap<Stamp, BTreeMap<NoteId, Note>>>,
+}
+
+impl NoteStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&mut self, id: BeadId, lineage: Stamp, note: Note) -> Option<Note> {
+        let entry = self
+            .by_bead
+            .entry(id)
+            .or_default()
+            .entry(lineage)
+            .or_default();
+        if let Some(existing) = entry.get(&note.id) {
+            return Some(existing.clone());
+        }
+        entry.insert(note.id.clone(), note);
+        None
+    }
+
+    pub fn replace(&mut self, id: BeadId, lineage: Stamp, note: Note) -> Option<Note> {
+        let entry = self
+            .by_bead
+            .entry(id)
+            .or_default()
+            .entry(lineage)
+            .or_default();
+        entry.insert(note.id.clone(), note)
+    }
+
+    pub fn get(&self, id: &BeadId, lineage: &Stamp, note_id: &NoteId) -> Option<&Note> {
+        self.by_bead
+            .get(id)
+            .and_then(|notes| notes.get(lineage))
+            .and_then(|notes| notes.get(note_id))
+    }
+
+    pub fn note_id_exists(&self, id: &BeadId, note_id: &NoteId) -> bool {
+        if let Some(lineages) = self.by_bead.get(id) {
+            for notes in lineages.values() {
+                if notes.contains_key(note_id) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    pub fn notes_for(&self, id: &BeadId, lineage: &Stamp) -> Vec<&Note> {
+        let Some(notes) = self.by_bead.get(id).and_then(|notes| notes.get(lineage)) else {
+            return Vec::new();
+        };
+        let mut out: Vec<&Note> = notes.values().collect();
+        out.sort_by(|a, b| a.at.cmp(&b.at).then_with(|| a.id.cmp(&b.id)));
+        out
+    }
+
+    pub fn iter_lineages(
+        &self,
+    ) -> impl Iterator<Item = (&BeadId, &Stamp, &BTreeMap<NoteId, Note>)> {
+        self.by_bead.iter().flat_map(|(id, lineages)| {
+            lineages
+                .iter()
+                .map(move |(lineage, notes)| (id, lineage, notes))
+        })
+    }
+
+    pub(crate) fn take_lineage_notes(
+        &mut self,
+        id: &BeadId,
+        lineage: &Stamp,
+    ) -> Option<BTreeMap<NoteId, Note>> {
+        let lineages = self.by_bead.get_mut(id)?;
+        let notes = lineages.remove(lineage)?;
+        if lineages.is_empty() {
+            self.by_bead.remove(id);
+        }
+        Some(notes)
+    }
+
+    pub fn join(a: &Self, b: &Self) -> Self {
+        let mut merged = NoteStore::new();
+        for (id, lineages) in a.by_bead.iter().chain(b.by_bead.iter()) {
+            let entry = merged.by_bead.entry(id.clone()).or_default();
+            for (lineage, notes) in lineages {
+                let lineage_entry = entry.entry(lineage.clone()).or_default();
+                for (note_id, note) in notes {
+                    match lineage_entry.get(note_id) {
+                        None => {
+                            lineage_entry.insert(note_id.clone(), note.clone());
+                        }
+                        Some(existing) => {
+                            if note_collision_cmp(existing, note) == Ordering::Less {
+                                lineage_entry.insert(note_id.clone(), note.clone());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        merged
+    }
+}
+
+pub fn note_collision_cmp(existing: &Note, incoming: &Note) -> Ordering {
+    existing
+        .at
+        .cmp(&incoming.at)
+        .then_with(|| existing.author.cmp(&incoming.author))
+        .then_with(|| {
+            sha256_bytes(existing.content.as_bytes())
+                .cmp(&sha256_bytes(incoming.content.as_bytes()))
+        })
+}
+
+#[derive(Serialize, Deserialize)]
+struct LineageNotes {
+    lineage: WireLineageStamp,
+    notes: BTreeMap<NoteId, Note>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct NoteStoreWire {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    by_bead: BTreeMap<BeadId, Vec<LineageNotes>>,
+}
+
+impl Serialize for NoteStore {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut by_bead = BTreeMap::new();
+        for (id, lineages) in &self.by_bead {
+            let entries = lineages
+                .iter()
+                .map(|(lineage, notes)| LineageNotes {
+                    lineage: WireLineageStamp::from(lineage.clone()),
+                    notes: notes.clone(),
+                })
+                .collect::<Vec<_>>();
+            if !entries.is_empty() {
+                by_bead.insert(id.clone(), entries);
+            }
+        }
+        let wire = NoteStoreWire { by_bead };
+        wire.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for NoteStore {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = NoteStoreWire::deserialize(deserializer)?;
+        let mut by_bead: BTreeMap<BeadId, BTreeMap<Stamp, BTreeMap<NoteId, Note>>> =
+            BTreeMap::new();
+        for (id, entries) in wire.by_bead {
+            let mut lineages: BTreeMap<Stamp, BTreeMap<NoteId, Note>> = BTreeMap::new();
+            for entry in entries {
+                let lineage = entry.lineage.stamp();
+                match lineages.get(&lineage) {
+                    Some(existing) => {
+                        let mut merged = existing.clone();
+                        for (note_id, note) in entry.notes {
+                            match merged.get(&note_id) {
+                                None => {
+                                    merged.insert(note_id, note);
+                                }
+                                Some(existing_note) => {
+                                    if note_collision_cmp(existing_note, &note) == Ordering::Less {
+                                        merged.insert(note_id, note);
+                                    }
+                                }
+                            }
+                        }
+                        lineages.insert(lineage, merged);
+                    }
+                    None => {
+                        lineages.insert(lineage, entry.notes);
+                    }
+                }
+            }
+            if !lineages.is_empty() {
+                by_bead.insert(id, lineages);
+            }
+        }
+        Ok(NoteStore { by_bead })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::identity::{ActorId, BeadId};
+    use crate::time::WriteStamp;
+
+    fn make_stamp(wall_ms: u64, counter: u32, actor: &str) -> Stamp {
+        Stamp::new(
+            WriteStamp::new(wall_ms, counter),
+            ActorId::new(actor).unwrap(),
+        )
+    }
+
+    fn actor_id(actor: &str) -> ActorId {
+        ActorId::new(actor).unwrap_or_else(|e| panic!("invalid actor id {actor}: {e}"))
+    }
+
+    fn bead_id(id: &str) -> BeadId {
+        BeadId::parse(id).unwrap_or_else(|e| panic!("invalid bead id {id}: {e}"))
+    }
+
+    #[test]
+    fn note_store_join_resolves_collisions_deterministically() {
+        let bead = bead_id("bd-note-join");
+        let note_id = NoteId::new("note-join").unwrap();
+        let lineage = make_stamp(1000, 0, "alice");
+        let note_a = Note::new(
+            note_id.clone(),
+            "alpha".to_string(),
+            actor_id("alice"),
+            WriteStamp::new(10, 0),
+        );
+        let note_b = Note::new(
+            note_id.clone(),
+            "beta".to_string(),
+            actor_id("bob"),
+            WriteStamp::new(20, 0),
+        );
+
+        let mut store_a = NoteStore::new();
+        store_a.insert(bead.clone(), lineage.clone(), note_a);
+        let mut store_b = NoteStore::new();
+        store_b.insert(bead.clone(), lineage.clone(), note_b.clone());
+
+        let joined_ab = NoteStore::join(&store_a, &store_b);
+        let joined_ba = NoteStore::join(&store_b, &store_a);
+
+        let stored_ab = joined_ab
+            .get(&bead, &lineage, &note_id)
+            .expect("note stored");
+        let stored_ba = joined_ba
+            .get(&bead, &lineage, &note_id)
+            .expect("note stored");
+
+        assert_eq!(stored_ab, stored_ba);
+        assert_eq!(stored_ab.content, "beta");
+    }
+}


### PR DESCRIPTION
🎯 **What:**
Split the large `crates/beads-core/src/state.rs` file into logical submodules under `crates/beads-core/src/state/`.

💡 **Why:**
The file was over 2500 lines long, containing multiple distinct components (`CanonicalState`, `LabelStore`, `DepStore`, `NoteStore`). Splitting it improves maintainability, readability, and compilation parallelism.

✅ **Verification:**
- Ran `cargo test -p beads-core` - All tests passed.
- Ran `cargo clippy -p beads-core` - No new warnings.
- Verified file structure and imports.

✨ **Result:**
`state.rs` is replaced by a modular `state/` directory. API compatibility is preserved via re-exports.

---
*PR created automatically by Jules for task [6295055905963461047](https://jules.google.com/task/6295055905963461047) started by @darinkishore*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/delightful-ai/beads-rs/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a file/module reorganization with minor visibility/type tweaks; functional behavior should be unchanged but there is some risk of missed import/re-export or serialization wiring regressions.
> 
> **Overview**
> Refactors the `beads-core` state layer by splitting the previously monolithic state implementation into focused modules: `state/canonical.rs`, `state/labels.rs`, `state/deps.rs`, and `state/notes.rs`, with a new `state/mod.rs` providing docs, shared helpers (e.g. `max_stamp`), and **API-preserving re-exports**.
> 
> As part of the split, collision-handling helpers are reorganized (`note_collision_cmp` moved into `state/notes.rs` with its test moved alongside; `bead_content_hash_for_collision` is now public and re-exported), and a few small signature/import cleanups were made (e.g. using `ContentHash`/`WriteStamp` directly and adding explicit tuple types in dependency iterators).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 690008b0c25b9a60f0cd0f46329feebde2906f60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->