### PR TITLE
Handle partially consumed values in for_each_unconsumed_temporary

### DIFF
--- a/lints/clippy_utils/src/visitors.rs
+++ b/lints/clippy_utils/src/visitors.rs
@@ -14,7 +14,7 @@ use rustc_hir::{
 use rustc_lint::LateContext;
 use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::adjustment::Adjust;
-use rustc_middle::ty::{self, Ty, TyCtxt, TypeckResults};
+use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::Span;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_span::Symbol;
@@ -690,7 +690,7 @@ pub fn for_each_unconsumed_temporary<'tcx, B>(
             }
             ExprKind::Field(base, ident) => {
                 let base_consume = if consume == Consumption::Yes {
-                    if !typeck.expr_ty(base).is_copy_modulo_regions(cx.tcx, cx.typing_env()) {
+                    if !crate::ty::is_copy(cx, typeck.expr_ty(base)) {
                         Consumption::Partial(FxHashSet::from_iter([ident.name]))
                     } else {
                         Consumption::No


### PR DESCRIPTION
Handle partially consumed values in for_each_unconsumed_temporary

This change updates the `for_each_unconsumed_temporary` visitor in `clippy_utils` to correctly handle partially consumed values, such as when a field is moved out of a struct literal.

Previously, `for_each_unconsumed_temporary` would either report the entire struct as unconsumed (even if a field was moved) or report nothing. This led to false positives or missed temporaries.

The visitor now uses a `Consumption` enum instead of a boolean flag to track consumption state:
- `Consumption::Yes`: Fully consumed.
- `Consumption::No`: Not consumed.
- `Consumption::Partial(FxHashSet<Symbol>)`: Partially consumed (specific fields moved).

This allows the visitor to:
1. Identify when a field access moves a value from a struct, marking the struct as partially consumed.
2. Iterate over fields of a partially consumed struct and only report the unconsumed fields as temporaries.

This improves the accuracy of lints relying on this utility (e.g., detecting droppable temporaries).

---
*PR created automatically by Jules for task [4589301458983263755](https://jules.google.com/task/4589301458983263755) started by @darinkishore*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/delightful-ai/beads-rs/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core traversal logic used by multiple lints; behavior changes could alter which temporaries are reported (false positives/negatives) across many expressions, though the change is localized to analysis code.
> 
> **Overview**
> Improves `for_each_unconsumed_temporary` to properly handle *partially consumed* temporaries instead of treating consumption as an all-or-nothing boolean.
> 
> This introduces a `Consumption` state (`Yes`/`No`/`Partial`) and updates the expression traversal to propagate partial moves through `Field`, `Struct`, `Tup`/`Array`, `If`, and block expressions, so only the still-unconsumed parts are reported to callers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a625dc86fd0015ee0e95d0ef33b5cd2966866dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->