### PR TITLE
Refactor CRDT trait and make CanonicalState::join infallible

### DIFF
--- a/crates/beads-core/src/bead.rs
+++ b/crates/beads-core/src/bead.rs
@@ -100,7 +100,7 @@ macro_rules! define_bead_fields {
     (
         $(pub $name:ident : $type:ty),* $(,)?
     ) => {
-        #[derive(Clone, Debug, Serialize, Deserialize)]
+        #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
         pub struct BeadFields {
             $(pub $name: Lww<$type>),*
         }
@@ -155,7 +155,7 @@ define_bead_fields! {
 }
 
 /// The Bead - core + scalar fields.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Bead {
     pub core: BeadCore,
     pub fields: BeadFields,

--- a/crates/beads-core/src/crdt.rs
+++ b/crates/beads-core/src/crdt.rs
@@ -6,6 +6,16 @@ use serde::{Deserialize, Serialize};
 
 use super::time::Stamp;
 
+/// A type that can be merged with another instance of itself deterministically.
+///
+/// Properties:
+/// - Commutative: join(a, b) == join(b, a)
+/// - Associative: join(join(a, b), c) == join(a, join(b, c))
+/// - Idempotent: join(a, a) == a
+pub trait Crdt: Clone + Sized {
+    fn join(&self, other: &Self) -> Self;
+}
+
 /// Last-Writer-Wins register.
 ///
 /// This is your CRDT join for scalar/atomic fields.
@@ -22,6 +32,16 @@ impl<T> Lww<T> {
     }
 }
 
+impl<T: Clone> Crdt for Lww<T> {
+    fn join(&self, other: &Self) -> Self {
+        if self.stamp >= other.stamp {
+            self.clone()
+        } else {
+            other.clone()
+        }
+    }
+}
+
 impl<T: Clone> Lww<T> {
     /// Deterministic merge - higher stamp wins.
     ///
@@ -30,11 +50,7 @@ impl<T: Clone> Lww<T> {
     /// - Associative: join(join(a, b), c) == join(a, join(b, c))
     /// - Idempotent: join(a, a) == a
     pub fn join(a: &Self, b: &Self) -> Self {
-        if a.stamp >= b.stamp {
-            a.clone()
-        } else {
-            b.clone()
-        }
+        Crdt::join(a, b)
     }
 }
 
@@ -45,3 +61,54 @@ impl<T: PartialEq> PartialEq for Lww<T> {
 }
 
 impl<T: Eq> Eq for Lww<T> {}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::identity::ActorId;
+    use crate::time::WriteStamp;
+    use std::fmt::Debug;
+
+    /// Verify CRDT laws for a given type.
+    ///
+    /// - Commutative: join(a, b) == join(b, a)
+    /// - Associative: join(join(a, b), c) == join(a, join(b, c))
+    /// - Idempotent: join(a, a) == a
+    pub fn crdt_laws<T: Crdt + PartialEq + Debug>(a: &T, b: &T, c: &T) {
+        // Idempotence
+        assert_eq!(a.join(a), *a, "idempotence failed for a");
+        assert_eq!(b.join(b), *b, "idempotence failed for b");
+        assert_eq!(c.join(c), *c, "idempotence failed for c");
+
+        // Commutativity
+        assert_eq!(a.join(b), b.join(a), "commutativity failed for a, b");
+        assert_eq!(a.join(c), c.join(a), "commutativity failed for a, c");
+        assert_eq!(b.join(c), c.join(b), "commutativity failed for b, c");
+
+        // Associativity
+        assert_eq!(
+            a.join(b).join(c),
+            a.join(&b.join(c)),
+            "associativity failed for a, b, c"
+        );
+    }
+
+    fn make_lww(val: &str, time: u64, actor: &str) -> Lww<String> {
+        Lww::new(
+            val.to_string(),
+            Stamp::new(
+                WriteStamp::new(time, 0),
+                ActorId::new(actor).expect("valid actor"),
+            ),
+        )
+    }
+
+    #[test]
+    fn lww_satisfies_laws() {
+        let a = make_lww("a", 100, "alice");
+        let b = make_lww("b", 200, "bob");
+        let c = make_lww("c", 150, "carol");
+
+        crdt_laws(&a, &b, &c);
+    }
+}

--- a/crates/beads-core/src/lib.rs
+++ b/crates/beads-core/src/lib.rs
@@ -51,7 +51,7 @@ pub use apply::{ApplyError, ApplyOutcome, NoteKey, apply_event};
 pub use bead::{Bead, BeadCore, BeadFields, BeadProjection, BeadView};
 pub use collections::{Label, Labels};
 pub use composite::{Claim, Closure, Note, Workflow};
-pub use crdt::Lww;
+pub use crdt::{Crdt, Lww};
 pub use dep::{
     AcyclicDepKey, DepAddKey, DepKey, DepSpec, DepSpecSet, FreeDepKey, NoCycleProof, ParentEdge,
 };

--- a/crates/beads-rs/src/daemon/coord/sync.rs
+++ b/crates/beads-rs/src/daemon/coord/sync.rs
@@ -271,27 +271,14 @@ impl Daemon {
                     let local_state = store.state.core().clone();
                     let merged = CanonicalState::join(&synced_state, &local_state);
 
-                    match merged {
-                        Ok(merged) => {
-                            let mut next_state = store.state.clone();
-                            next_state.set_core_state(merged);
-                            store.state = next_state;
-                            repo_state.complete_sync(wall_ms);
-                            // Still dirty from mutations during sync - reschedule
-                            repo_state.dirty = true;
-                            reschedule_sync = true;
-                            sync_succeeded = true;
-                        }
-                        Err(errs) => {
-                            tracing::error!(
-                                "merge after sync failed for {:?}: {:?}; preserving local state",
-                                remote,
-                                errs
-                            );
-                            repo_state.fail_sync();
-                            backoff_ms = Some(repo_state.backoff_ms());
-                        }
-                    }
+                    let mut next_state = store.state.clone();
+                    next_state.set_core_state(merged);
+                    store.state = next_state;
+                    repo_state.complete_sync(wall_ms);
+                    // Still dirty from mutations during sync - reschedule
+                    repo_state.dirty = true;
+                    reschedule_sync = true;
+                    sync_succeeded = true;
                 } else {
                     // No mutations during sync - just take synced state
                     let mut next_state = store.state.clone();

--- a/crates/beads-rs/src/daemon/git_worker.rs
+++ b/crates/beads-rs/src/daemon/git_worker.rs
@@ -492,8 +492,7 @@ fn build_load_result(inputs: LoadResultInputs) -> Result<LoadResult, SyncError> 
         divergence,
         force_push,
     } = inputs;
-    let merged = CanonicalState::join(&local_state, &remote_state)
-        .map_err(|errs| SyncError::MergeConflict { errors: errs })?;
+    let merged = CanonicalState::join(&local_state, &remote_state);
 
     let root_slug = local_slug.or(remote_slug);
 

--- a/crates/beads-rs/src/git/checkpoint/import.rs
+++ b/crates/beads-rs/src/git/checkpoint/import.rs
@@ -590,7 +590,6 @@ pub fn merge_store_states(
     b: &StoreState,
 ) -> Result<StoreState, CheckpointImportError> {
     let mut merged = StoreState::new();
-    let mut errors = Vec::new();
 
     let mut namespaces: BTreeSet<NamespaceId> = BTreeSet::new();
     namespaces.extend(a.namespaces().map(|(ns, _)| ns));
@@ -600,24 +599,14 @@ pub fn merge_store_states(
         let left = a.get(&namespace);
         let right = b.get(&namespace);
         let out = match (left, right) {
-            (Some(a_state), Some(b_state)) => match CanonicalState::join(a_state, b_state) {
-                Ok(state) => state,
-                Err(errs) => {
-                    errors.extend(errs);
-                    a_state.clone()
-                }
-            },
+            (Some(a_state), Some(b_state)) => CanonicalState::join(a_state, b_state),
             (Some(state), None) | (None, Some(state)) => state.clone(),
             (None, None) => CanonicalState::default(),
         };
         state_for_namespace(&mut merged, &namespace).clone_from(&out);
     }
 
-    if errors.is_empty() {
-        Ok(merged)
-    } else {
-        Err(CheckpointImportError::Merge(errors))
-    }
+    Ok(merged)
 }
 
 /// Lift a legacy, non-namespaced state into the core namespace.

--- a/crates/beads-rs/src/git/sync.rs
+++ b/crates/beads-rs/src/git/sync.rs
@@ -505,8 +505,7 @@ impl SyncProcess<Fetched> {
         }
 
         // Pairwise CRDT merge
-        let mut merged = CanonicalState::join(local_state, &remote_state)
-            .map_err(|errs| SyncError::MergeConflict { errors: errs })?;
+        let mut merged = CanonicalState::join(local_state, &remote_state);
 
         // Garbage collect tombstones if configured.
         if let Some(ttl_ms) = config.tombstone_ttl_ms {

--- a/crates/beads-rs/tests/core_state_fingerprint.rs
+++ b/crates/beads-rs/tests/core_state_fingerprint.rs
@@ -164,10 +164,8 @@ proptest! {
 
     #[test]
     fn join_commutative(a in state_strategy(), b in state_strategy()) {
-        let ab = CanonicalState::join(&a, &b)
-            .unwrap_or_else(|e| panic!("join failed: {e:?}"));
-        let ba = CanonicalState::join(&b, &a)
-            .unwrap_or_else(|e| panic!("join failed: {e:?}"));
+        let ab = CanonicalState::join(&a, &b);
+        let ba = CanonicalState::join(&b, &a);
         prop_assert_eq!(state_fingerprint(&ab), state_fingerprint(&ba));
     }
 
@@ -183,30 +181,23 @@ proptest! {
         let mut state_b = CanonicalState::new();
         state_b.insert_live(make_bead(&id, &stamp_b));
 
-        let ab = CanonicalState::join(&state_a, &state_b)
-            .unwrap_or_else(|e| panic!("join failed: {e:?}"));
-        let ba = CanonicalState::join(&state_b, &state_a)
-            .unwrap_or_else(|e| panic!("join failed: {e:?}"));
+        let ab = CanonicalState::join(&state_a, &state_b);
+        let ba = CanonicalState::join(&state_b, &state_a);
         prop_assert_eq!(state_fingerprint(&ab), state_fingerprint(&ba));
     }
 
     #[test]
     fn join_idempotent(a in state_strategy()) {
-        let aa = CanonicalState::join(&a, &a)
-            .unwrap_or_else(|e| panic!("join failed: {e:?}"));
+        let aa = CanonicalState::join(&a, &a);
         prop_assert_eq!(state_fingerprint(&aa), state_fingerprint(&a));
     }
 
     #[test]
     fn join_associative(a in state_strategy(), b in state_strategy(), c in state_strategy()) {
-        let ab = CanonicalState::join(&a, &b)
-            .unwrap_or_else(|e| panic!("join failed: {e:?}"));
-        let left = CanonicalState::join(&ab, &c)
-            .unwrap_or_else(|e| panic!("join failed: {e:?}"));
-        let bc = CanonicalState::join(&b, &c)
-            .unwrap_or_else(|e| panic!("join failed: {e:?}"));
-        let right = CanonicalState::join(&a, &bc)
-            .unwrap_or_else(|e| panic!("join failed: {e:?}"));
+        let ab = CanonicalState::join(&a, &b);
+        let left = CanonicalState::join(&ab, &c);
+        let bc = CanonicalState::join(&b, &c);
+        let right = CanonicalState::join(&a, &bc);
         prop_assert_eq!(state_fingerprint(&left), state_fingerprint(&right));
     }
 }

--- a/crates/beads-rs/tests/integration/core/apply.rs
+++ b/crates/beads-rs/tests/integration/core/apply.rs
@@ -143,8 +143,8 @@ fn join_bead_collision_is_deterministic_and_inserts_lineage_tombstone() {
     let event_b = validated(event_body_with_delta(51, delta_b));
     apply_event(&mut state_b, &event_b).expect("apply b");
 
-    let merged_ab = CanonicalState::join(&state_a, &state_b).expect("merge ab");
-    let merged_ba = CanonicalState::join(&state_b, &state_a).expect("merge ba");
+    let merged_ab = CanonicalState::join(&state_a, &state_b);
+    let merged_ba = CanonicalState::join(&state_b, &state_a);
 
     let winner_ab = merged_ab.get_live(&bead).expect("winner");
     let winner_ba = merged_ba.get_live(&bead).expect("winner");


### PR DESCRIPTION
This PR introduces a standardized `Crdt` trait in `beads-core` and refactors `CanonicalState::join` to be infallible.

### 💡 What
- Defined `pub trait Crdt: Clone + Sized { fn join(&self, other: &Self) -> Self; }` in `crates/beads-core/src/crdt.rs`.
- Implemented `Crdt` for all core CRDT types: `Lww`, `OrSet`, `LabelState`, `LabelStore`, `DepStore`, `NoteStore`, and `CanonicalState`.
- Removed `Result<Self, Vec<CoreError>>` from `CanonicalState::join`, changing it to return `Self`. The previous implementation never returned `Err`, so this aligns the type with reality.
- Updated call sites in `beads-rs` (sync logic, tests) to remove `unwrap()` and `match` blocks for merge results.
- Added `crdt_laws` test helper and applied it to all implementations to enforce algebraic properties.

### 🎯 Why
- **Trait Design:** Standardizes the "merge" capability across the system, making it explicit which types are CRDTs and ensuring they behave correctly (laws).
- **Type Design:** "Types should tell the truth." `CanonicalState::join` claimed it could fail but never did. Making it infallible simplifies consumption and removes dead error handling paths.
- **Scatter:** Centralizes CRDT definition and behavior contract.

### 🛡️ Verification
- Ran `cargo test -p beads-core` (unit tests).
- Ran `cargo test -p beads-rs --test core_state_fingerprint` (CRDT property tests).
- Ran `cargo test -p beads-rs --test integration` (integration tests using apply/join).
- Validated that `CanonicalState` collision resolution logic remains deterministic and correct.

---
*PR created automatically by Jules for task [2131899907248910425](https://jules.google.com/task/2131899907248910425) started by @darinkishore*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/delightful-ai/beads-rs/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core state merge API and collision-resolution behavior surfaced to sync/import code paths; while deterministic, merge semantics are critical and could affect conflict outcomes across replicas.
> 
> **Overview**
> Introduces a `Crdt` trait and implements it across core CRDT types (`Lww`, `OrSet`, label/dep/note stores, and `CanonicalState`), plus adds reusable tests to enforce commutativity/associativity/idempotence for each implementation.
> 
> Refactors `CanonicalState::join` to be **infallible**, resolving bead ID collisions deterministically (creation stamp/content-hash tie-break with lineage tombstones) instead of returning a `Result`, and updates sync/checkpoint merge paths and tests to remove now-dead error handling. Also derives `PartialEq/Eq` for several state structs to support the new law tests and comparisons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1111b13ce68b437c8d57a04c2d538d7be008ee3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->