### PR TITLE
Improve bd CLI UX and help surfaces

### DIFF
--- a/crates/beads-cli/src/cli.rs
+++ b/crates/beads-cli/src/cli.rs
@@ -6,10 +6,19 @@ use clap::{ArgAction, Parser, Subcommand, builder::BoolishValueParser};
 use crate::backend::CliHostBackend;
 use crate::commands;
 use crate::commands::CommandError;
-use crate::commands::setup::{SetupCmd, handle_aider, handle_claude, handle_cursor};
+use crate::commands::setup::{
+    SetupCmd, handle_aider, handle_claude, handle_cursor, handle_file_recipe, handle_setup_list,
+};
 use crate::runtime::CliRuntimeCtx;
 use beads_surface::ipc::{EmptyPayload, IpcError, RepoCtx, Request, Response, send_request};
 
+const CREATE_AFTER_HELP: &str = "Examples:\n  bd create \"Write CLI docs\" -p1 -t task\n  printf 'Detailed context\\n' | bd create \"Fix parser\" --stdin\n  bd create \"Refactor parser\" --body-file notes.md --design-file plan.md\n  bd create --file backlog.md";
+const SHOW_AFTER_HELP: &str = "Examples:\n  bd show beads-rs-k8u3\n  bd show --id beads-rs-k8u3 --id beads-rs-k8u3.5\n  bd show --current\n  bd show beads-rs-k8u3 --refs\n  bd show beads-rs-k8u3 --children\n  bd show beads-rs-k8u3 --short\n  bd help --advanced show";
+const LIST_AFTER_HELP: &str = "Examples:\n  bd list\n  bd list --all --long\n  bd list --parent beads-rs-k8u3 --tree\n  bd list --status open --label cli -L\n  bd list --sort priority:desc";
+const UPDATE_AFTER_HELP: &str = "Examples:\n  bd update beads-rs-k8u3 --status in_progress --priority 1\n  printf 'Refined description\\n' | bd update beads-rs-k8u3 --stdin\n  bd update beads-rs-k8u3 --body-file notes.md --design-file design.md\n  bd update beads-rs-k8u3 --add-label cli --notes \"help UX pass\"";
+const DEP_AFTER_HELP: &str = "Examples:\n  bd dep add beads-rs-k8u3.2 beads-rs-k8u3.9\n  bd dep beads-rs-k8u3.9 --blocks beads-rs-k8u3.2\n  bd dep beads-rs-k8u3.2 --depends-on beads-rs-k8u3.9\n  bd dep tree beads-rs-k8u3";
+const PRIME_AFTER_HELP: &str = "Examples:\n  bd prime\n  bd prime --mcp\n  bd prime --full --stealth\n  bd prime --export > /tmp/beads-context.txt";
+const SETUP_AFTER_HELP: &str = "Examples:\n  bd setup list\n  bd setup claude\n  bd setup cursor --check\n  bd setup codex\n  bd setup windsurf --remove";
 #[derive(Parser, Debug)]
 #[command(
     name = "bd",
@@ -83,14 +92,27 @@ pub enum Command {
     Init,
 
     /// Create a new bead.
-    #[command(alias = "new")]
+    #[command(
+        visible_alias = "new",
+        long_about = "Create a bead from a title or import a batch from markdown. Alias: `new`. This is the fastest path for capturing new work, especially when you want the resulting bead id back immediately.",
+        after_help = CREATE_AFTER_HELP
+    )]
     Create(commands::create::CreateArgs),
 
     /// Show a bead.
+    #[command(
+        visible_alias = "view",
+        long_about = "Show the current state of one or more beads, including notes, dependency relationships, and child beads when that detail is available from the daemon. Use `--current` to resolve the active bead from your current jj change or claimed in-progress work, `--short` for a compact read, `--refs` for reverse references, and `--children` for a child-only view.",
+        after_help = SHOW_AFTER_HELP
+    )]
     Show(commands::show::ShowArgs),
 
     /// List beads.
-    #[command(alias = "ls")]
+    #[command(
+        visible_alias = "ls",
+        long_about = "List beads with optional text search, filters, sorting, and output tweaks. Alias: `ls`. Human-mode `bd list` defaults to open work; add `--all` for the full backlog, `--long` for multi-line detail, and `--tree` with `--parent` for descendant views.",
+        after_help = LIST_AFTER_HELP
+    )]
     List(commands::list::ListArgs),
 
     /// Search beads by text (alias for list QUERY).
@@ -133,6 +155,10 @@ pub enum Command {
     Upgrade(commands::upgrade::UpgradeArgs),
 
     /// Update a bead.
+    #[command(
+        long_about = "Update bead fields, labels, notes, dependencies, assignee compatibility state, and workflow status in one invocation.",
+        after_help = UPDATE_AFTER_HELP
+    )]
     Update(commands::update::UpdateArgs),
 
     /// Close a bead.
@@ -151,15 +177,19 @@ pub enum Command {
     Unclaim(commands::unclaim::UnclaimArgs),
 
     /// Comments (alias for notes).
-    #[command(alias = "notes")]
+    #[command(visible_alias = "notes")]
     Comments(commands::comments::CommentsArgs),
 
     /// Add a comment (compat alias).
-    #[command(alias = "note")]
+    #[command(visible_alias = "note")]
     Comment(commands::comments::CommentAddArgs),
 
     /// Dependency operations.
-    #[command(alias = "deps", alias = "dependencies")]
+    #[command(
+        visible_aliases = ["deps", "dependencies"],
+        long_about = "Inspect and edit dependency edges between beads. Aliases: `deps`, `dependencies`. `add` means FROM depends on TO, so TO must complete before FROM is ready. Convenience form: `bd dep <blocker> --blocks <blocked>` means the blocked bead depends on the blocker.",
+        after_help = DEP_AFTER_HELP
+    )]
     Dep {
         #[command(subcommand)]
         cmd: commands::dep::DepCmd,
@@ -181,12 +211,20 @@ pub enum Command {
     Status,
 
     /// Output AI-optimized workflow context.
-    Prime,
+    #[command(
+        long_about = "Print the short, dense workflow context that helps an agent or human reload the local beads conventions quickly after entering a repo.",
+        after_help = PRIME_AFTER_HELP
+    )]
+    Prime(commands::prime::PrimeArgs),
 
     /// Display instructions for configuring AGENTS.md.
     Onboard(commands::onboard::OnboardArgs),
 
     /// Setup integration with AI editors.
+    #[command(
+        long_about = "Install, inspect, or remove editor integrations that make beads workflows easier to use from AI tooling such as Claude Code, Cursor, Aider, Codex, Gemini, OpenCode, and Windsurf.",
+        after_help = SETUP_AFTER_HELP
+    )]
     Setup {
         #[command(subcommand)]
         cmd: SetupCmd,
@@ -282,7 +320,7 @@ pub fn command_name(command: &Command) -> String {
         Command::Label { cmd } => format!("label.{}", label_cmd_name(cmd)),
         Command::Epic { cmd } => format!("epic.{}", epic_cmd_name(cmd)),
         Command::Status => "status".to_string(),
-        Command::Prime => "prime".to_string(),
+        Command::Prime(_) => "prime".to_string(),
         Command::Onboard(_) => "onboard".to_string(),
         Command::Setup { cmd } => format!("setup.{}", setup_cmd_name(cmd)),
         Command::Migrate { cmd } => format!("migrate.{}", migrate_cmd_name(cmd)),
@@ -321,7 +359,7 @@ where
         Command::Daemon { cmd } => match cmd {
             commands::daemon::DaemonCmd::Run => host.run_daemon_command(),
         },
-        Command::Prime => handle_prime(host),
+        Command::Prime(args) => handle_prime(host, args),
         Command::Setup { cmd } => handle_setup::<H>(cmd),
         Command::Onboard(args) => handle_onboard(host, args.output.as_deref()),
         Command::Store { cmd } => commands::store::handle(json, cmd, backend),
@@ -384,7 +422,7 @@ where
         Command::Admin { cmd } => commands::admin::handle(ctx, cmd).map_err(Into::into),
         Command::Migrate { cmd } => commands::migrate::handle(ctx, cmd, backend),
         Command::Daemon { .. }
-        | Command::Prime
+        | Command::Prime(_)
         | Command::Setup { .. }
         | Command::Onboard(_)
         | Command::Store { .. }
@@ -398,20 +436,25 @@ where
     H::Error: From<commands::setup::SetupError>,
 {
     match cmd {
+        SetupCmd::List => handle_setup_list(),
         SetupCmd::Claude(args) => handle_claude(args.project, args.check, args.remove),
         SetupCmd::Cursor(args) => handle_cursor(args.check, args.remove),
         SetupCmd::Aider(args) => handle_aider(args.check, args.remove),
+        SetupCmd::Codex(args) => handle_file_recipe("codex", args),
+        SetupCmd::Gemini(args) => handle_file_recipe("gemini", args),
+        SetupCmd::OpenCode(args) => handle_file_recipe("opencode", args),
+        SetupCmd::Windsurf(args) => handle_file_recipe("windsurf", args),
     }
     .map_err(Into::into)
 }
 
-fn handle_prime<H>(host: &H) -> std::result::Result<(), H::Error>
+fn handle_prime<H>(host: &H, args: commands::prime::PrimeArgs) -> std::result::Result<(), H::Error>
 where
     H: CliHost,
     H::Error: From<IpcError>,
 {
     let mut stdout = std::io::stdout().lock();
-    if let Err(err) = commands::prime::write_context_if(&mut stdout, host.in_beads_repo())
+    if let Err(err) = commands::prime::write_context_if(&mut stdout, host.in_beads_repo(), &args)
         && err.kind() != std::io::ErrorKind::BrokenPipe
     {
         return Err(IpcError::from(err).into());
@@ -550,9 +593,14 @@ fn maintenance_cmd_name(cmd: &commands::admin::AdminMaintenanceCmd) -> &'static 
 
 fn setup_cmd_name(cmd: &SetupCmd) -> &'static str {
     match cmd {
+        SetupCmd::List => "list",
         SetupCmd::Claude(_) => "claude",
         SetupCmd::Cursor(_) => "cursor",
         SetupCmd::Aider(_) => "aider",
+        SetupCmd::Codex(_) => "codex",
+        SetupCmd::Gemini(_) => "gemini",
+        SetupCmd::OpenCode(_) => "opencode",
+        SetupCmd::Windsurf(_) => "windsurf",
     }
 }
 
@@ -567,5 +615,69 @@ fn migrate_cmd_name(cmd: &commands::migrate::MigrateCmd) -> &'static str {
 fn daemon_cmd_name(cmd: &commands::daemon::DaemonCmd) -> &'static str {
     match cmd {
         commands::daemon::DaemonCmd::Run => "run",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_create_accepts_compat_text_input_flags() {
+        let cli = parse_from([
+            "bd",
+            "create",
+            "Write docs",
+            "--desc",
+            "from desc",
+            "--message",
+            "from desc",
+            "--body-file",
+            "body.md",
+            "--design-file",
+            "design.md",
+        ]);
+
+        match cli.command {
+            Command::Create(args) => {
+                assert_eq!(args.description.as_deref(), Some("from desc"));
+                assert_eq!(args.message.as_deref(), Some("from desc"));
+                assert_eq!(args.body_file.as_deref(), Some(Path::new("body.md")));
+                assert_eq!(args.design_file.as_deref(), Some(Path::new("design.md")));
+            }
+            other => panic!("expected create command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_update_accepts_stdin_and_design_file_flags() {
+        let cli = parse_from([
+            "bd",
+            "update",
+            "beads-rs-k8u3",
+            "--stdin",
+            "--design-file",
+            "design.md",
+        ]);
+
+        match cli.command {
+            Command::Update(args) => {
+                assert!(args.stdin);
+                assert_eq!(args.design_file.as_deref(), Some(Path::new("design.md")));
+            }
+            other => panic!("expected update command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_update_accepts_desc_alias() {
+        let cli = parse_from(["bd", "update", "beads-rs-k8u3", "--desc", "from desc"]);
+
+        match cli.command {
+            Command::Update(args) => {
+                assert_eq!(args.description.as_deref(), Some("from desc"));
+            }
+            other => panic!("expected update command, got {other:?}"),
+        }
     }
 }

--- a/crates/beads-cli/src/commands/create.rs
+++ b/crates/beads-cli/src/commands/create.rs
@@ -5,9 +5,10 @@ use crate::validation::{normalize_bead_id_for, normalize_dep_specs, validation_e
 use clap::Args;
 
 use super::common::fetch_issue;
+use super::input::{FileTextArg, InlineTextArg, resolve_text_input, text_input_uses_stdin};
 use super::{CommandResult, print_ok};
 use crate::render::{print_json, print_line};
-use crate::runtime::{CliRuntimeCtx, resolve_description, send, send_raw};
+use crate::runtime::{CliRuntimeCtx, send, send_raw};
 use beads_api::{Issue, QueryResult};
 use beads_core::{BeadType, Priority};
 use beads_surface::OpResult;
@@ -36,12 +37,28 @@ pub struct CreateArgs {
     pub priority: Option<Priority>,
 
     /// Description.
-    #[arg(short = 'd', long, allow_hyphen_values = true)]
+    #[arg(short = 'd', long, alias = "desc", allow_hyphen_values = true)]
     pub description: Option<String>,
 
     /// Alias for --description (GitHub CLI convention).
     #[arg(long = "body", hide = true, allow_hyphen_values = true)]
     pub body: Option<String>,
+
+    /// Alias for --description (git commit convention).
+    #[arg(short = 'm', long = "message", hide = true, allow_hyphen_values = true)]
+    pub message: Option<String>,
+
+    /// Read description from file (use `-` for stdin).
+    #[arg(long = "body-file", value_name = "PATH")]
+    pub body_file: Option<std::path::PathBuf>,
+
+    /// Alias for --body-file.
+    #[arg(long = "description-file", hide = true, value_name = "PATH")]
+    pub description_file: Option<std::path::PathBuf>,
+
+    /// Read description from stdin.
+    #[arg(long)]
+    pub stdin: bool,
 
     /// Assignee (compat; only supports current actor).
     #[arg(short = 'a', long)]
@@ -58,6 +75,10 @@ pub struct CreateArgs {
     /// Design text.
     #[arg(long, allow_hyphen_values = true)]
     pub design: Option<String>,
+
+    /// Read design text from file (use `-` for stdin).
+    #[arg(long = "design-file", value_name = "PATH")]
+    pub design_file: Option<std::path::PathBuf>,
 
     /// Acceptance criteria text.
     #[arg(
@@ -103,7 +124,65 @@ pub fn handle(ctx: &CliRuntimeCtx, mut args: CreateArgs) -> CommandResult<()> {
     }
 
     let title = resolve_title(args.title.take(), args.title_flag.take())?;
-    let description = resolve_description(args.description.take(), args.body.take())?;
+    let description_sources_inline = [
+        InlineTextArg {
+            flag: "--description",
+            value: args.description.as_deref(),
+        },
+        InlineTextArg {
+            flag: "--body",
+            value: args.body.as_deref(),
+        },
+        InlineTextArg {
+            flag: "--message",
+            value: args.message.as_deref(),
+        },
+    ];
+    let description_sources_files = [
+        FileTextArg {
+            flag: "--body-file",
+            path: args.body_file.as_deref(),
+        },
+        FileTextArg {
+            flag: "--description-file",
+            path: args.description_file.as_deref(),
+        },
+    ];
+    let design_sources_inline = [InlineTextArg {
+        flag: "--design",
+        value: args.design.as_deref(),
+    }];
+    let design_sources_files = [FileTextArg {
+        flag: "--design-file",
+        path: args.design_file.as_deref(),
+    }];
+    if text_input_uses_stdin(
+        &description_sources_inline,
+        &description_sources_files,
+        args.stdin,
+        true,
+    ) && text_input_uses_stdin(&design_sources_inline, &design_sources_files, false, false)
+    {
+        return Err(validation_error(
+            "stdin",
+            "description and design cannot both read from stdin in the same invocation; use a file for one of them",
+        )
+        .into());
+    }
+    let description = resolve_text_input(
+        "description",
+        &description_sources_inline,
+        &description_sources_files,
+        args.stdin,
+        true,
+    )?;
+    let design = resolve_text_input(
+        "design",
+        &design_sources_inline,
+        &design_sources_files,
+        false,
+        false,
+    )?;
 
     let bead_type = args.bead_type.unwrap_or(BeadType::Task);
     let priority = args.priority.unwrap_or_default();
@@ -139,7 +218,7 @@ pub fn handle(ctx: &CliRuntimeCtx, mut args: CreateArgs) -> CommandResult<()> {
             bead_type,
             priority,
             description,
-            design: args.design,
+            design,
             acceptance_criteria: args.acceptance,
             assignee: args.assignee,
             external_ref: args.external_ref,
@@ -557,4 +636,63 @@ fn parse_md_list(content: &str) -> Vec<String> {
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::CommandError;
+    use beads_core::NamespaceId;
+
+    fn sample_ctx() -> CliRuntimeCtx {
+        CliRuntimeCtx {
+            repo: std::path::PathBuf::from("/tmp/beads"),
+            json: false,
+            namespace: Some(NamespaceId::core()),
+            durability: None,
+            client_request_id: None,
+            require_min_seen: None,
+            wait_timeout_ms: None,
+            actor_id: None,
+        }
+    }
+
+    #[test]
+    fn create_rejects_double_stdin_usage() {
+        let err = handle(
+            &sample_ctx(),
+            CreateArgs {
+                title: Some("Title".to_string()),
+                title_flag: None,
+                file: None,
+                bead_type: None,
+                priority: None,
+                description: None,
+                body: None,
+                message: None,
+                body_file: None,
+                description_file: None,
+                stdin: true,
+                assignee: None,
+                labels: Vec::new(),
+                label: Vec::new(),
+                design: None,
+                design_file: Some(std::path::PathBuf::from("-")),
+                acceptance: None,
+                external_ref: None,
+                id: None,
+                parent: None,
+                deps: Vec::new(),
+                estimate: None,
+                force: false,
+            },
+        )
+        .expect_err("double stdin usage must fail");
+
+        assert!(matches!(err, CommandError::Validation(_)));
+        assert!(
+            err.to_string()
+                .contains("description and design cannot both read from stdin")
+        );
+    }
 }

--- a/crates/beads-cli/src/commands/input.rs
+++ b/crates/beads-cli/src/commands/input.rs
@@ -1,0 +1,364 @@
+use std::fs;
+use std::io::Read;
+use std::path::Path;
+
+use crate::validation::{Result, validation_error};
+
+#[derive(Clone, Copy)]
+pub(crate) struct InlineTextArg<'a> {
+    pub flag: &'a str,
+    pub value: Option<&'a str>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct FileTextArg<'a> {
+    pub flag: &'a str,
+    pub path: Option<&'a Path>,
+}
+
+pub(crate) fn text_input_uses_stdin(
+    inline: &[InlineTextArg<'_>],
+    files: &[FileTextArg<'_>],
+    stdin_flag: bool,
+    inline_dash_reads_stdin: bool,
+) -> bool {
+    stdin_flag
+        || files
+            .iter()
+            .filter_map(|arg| arg.path)
+            .any(|path| path == Path::new("-"))
+        || (inline_dash_reads_stdin
+            && inline
+                .iter()
+                .filter_map(|arg| arg.value)
+                .any(|value| value == "-"))
+}
+
+pub(crate) fn resolve_text_input(
+    field: &str,
+    inline: &[InlineTextArg<'_>],
+    files: &[FileTextArg<'_>],
+    stdin_flag: bool,
+    inline_dash_reads_stdin: bool,
+) -> Result<Option<String>> {
+    let mut stdin = std::io::stdin().lock();
+    resolve_text_input_with_reader(
+        field,
+        inline,
+        files,
+        stdin_flag,
+        inline_dash_reads_stdin,
+        &mut stdin,
+    )
+}
+
+fn resolve_text_input_with_reader<R: Read>(
+    field: &str,
+    inline: &[InlineTextArg<'_>],
+    files: &[FileTextArg<'_>],
+    stdin_flag: bool,
+    inline_dash_reads_stdin: bool,
+    stdin: &mut R,
+) -> Result<Option<String>> {
+    let mut sources = Vec::new();
+
+    if stdin_flag {
+        sources.push(TextSource::Stdin { flag: "--stdin" });
+    }
+
+    for arg in files {
+        if let Some(path) = arg.path {
+            if path == Path::new("-") {
+                sources.push(TextSource::Stdin { flag: arg.flag });
+            } else {
+                sources.push(TextSource::File {
+                    flag: arg.flag,
+                    path,
+                });
+            }
+        }
+    }
+
+    for arg in inline {
+        if let Some(value) = arg.value {
+            if inline_dash_reads_stdin && value == "-" {
+                sources.push(TextSource::Stdin { flag: arg.flag });
+            } else {
+                sources.push(TextSource::Inline {
+                    flag: arg.flag,
+                    value,
+                });
+            }
+        }
+    }
+
+    if sources.is_empty() {
+        return Ok(None);
+    }
+
+    let mut resolved = Vec::with_capacity(sources.len());
+    let mut stdin_value: Option<String> = None;
+
+    for source in sources {
+        let source_value = match source {
+            TextSource::Inline { flag, value } => ResolvedTextSource {
+                value: value.to_string(),
+                display: format!("{flag}={value:?}"),
+            },
+            TextSource::File { flag, path } => {
+                let content = fs::read_to_string(path).map_err(|err| {
+                    validation_error(
+                        field,
+                        format!("failed to read {} {}: {err}", flag, path.display()),
+                    )
+                })?;
+                ResolvedTextSource {
+                    value: content,
+                    display: format!("{flag}=@{}", path.display()),
+                }
+            }
+            TextSource::Stdin { flag } => {
+                let content = if let Some(existing) = stdin_value.as_ref() {
+                    existing.clone()
+                } else {
+                    let mut content = String::new();
+                    stdin.read_to_string(&mut content).map_err(|err| {
+                        validation_error(field, format!("failed to read stdin for {flag}: {err}"))
+                    })?;
+                    stdin_value = Some(content.clone());
+                    content
+                };
+                ResolvedTextSource {
+                    value: content,
+                    display: flag.to_string(),
+                }
+            }
+        };
+        resolved.push(source_value);
+    }
+
+    let first = resolved
+        .first()
+        .expect("resolved sources must be non-empty after non-empty input");
+    for other in resolved.iter().skip(1) {
+        if other.value != first.value {
+            return Err(validation_error(
+                field,
+                format!(
+                    "cannot specify both {} and {} with different values",
+                    first.display, other.display
+                ),
+            ));
+        }
+    }
+
+    Ok(Some(first.value.clone()))
+}
+
+enum TextSource<'a> {
+    Inline { flag: &'a str, value: &'a str },
+    File { flag: &'a str, path: &'a Path },
+    Stdin { flag: &'a str },
+}
+
+struct ResolvedTextSource {
+    value: String,
+    display: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn resolve_text_input_accepts_matching_inline_aliases() {
+        let value = resolve_text_input_with_reader(
+            "description",
+            &[
+                InlineTextArg {
+                    flag: "--description",
+                    value: Some("same"),
+                },
+                InlineTextArg {
+                    flag: "--message",
+                    value: Some("same"),
+                },
+            ],
+            &[],
+            false,
+            true,
+            &mut Cursor::new(Vec::<u8>::new()),
+        )
+        .expect("matching aliases should succeed");
+
+        assert_eq!(value.as_deref(), Some("same"));
+    }
+
+    #[test]
+    fn resolve_text_input_rejects_conflicting_inline_aliases() {
+        let err = resolve_text_input_with_reader(
+            "description",
+            &[
+                InlineTextArg {
+                    flag: "--description",
+                    value: Some("a"),
+                },
+                InlineTextArg {
+                    flag: "--message",
+                    value: Some("b"),
+                },
+            ],
+            &[],
+            false,
+            true,
+            &mut Cursor::new(Vec::<u8>::new()),
+        )
+        .expect_err("conflicting aliases should fail");
+
+        assert_eq!(
+            err,
+            validation_error(
+                "description",
+                "cannot specify both --description=\"a\" and --message=\"b\" with different values"
+            )
+        );
+    }
+
+    #[test]
+    fn resolve_text_input_reads_body_file() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let body_path = dir.path().join("body.md");
+        fs::write(&body_path, "from file\n").expect("write body");
+
+        let value = resolve_text_input_with_reader(
+            "description",
+            &[],
+            &[FileTextArg {
+                flag: "--body-file",
+                path: Some(body_path.as_path()),
+            }],
+            false,
+            true,
+            &mut Cursor::new(Vec::<u8>::new()),
+        )
+        .expect("body file should resolve");
+
+        assert_eq!(value.as_deref(), Some("from file\n"));
+    }
+
+    #[test]
+    fn resolve_text_input_rejects_conflicting_file_and_inline_values() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let body_path = dir.path().join("body.md");
+        fs::write(&body_path, "from file\n").expect("write body");
+
+        let err = resolve_text_input_with_reader(
+            "description",
+            &[InlineTextArg {
+                flag: "--description",
+                value: Some("inline"),
+            }],
+            &[FileTextArg {
+                flag: "--body-file",
+                path: Some(body_path.as_path()),
+            }],
+            false,
+            true,
+            &mut Cursor::new(Vec::<u8>::new()),
+        )
+        .expect_err("conflicting file and inline should fail");
+
+        assert_eq!(
+            err,
+            validation_error(
+                "description",
+                format!(
+                    "cannot specify both --body-file=@{} and --description=\"inline\" with different values",
+                    body_path.display()
+                )
+            )
+        );
+    }
+
+    #[test]
+    fn resolve_text_input_reads_stdin_from_flag() {
+        let value = resolve_text_input_with_reader(
+            "description",
+            &[],
+            &[],
+            true,
+            true,
+            &mut Cursor::new("from stdin\n"),
+        )
+        .expect("stdin should resolve");
+
+        assert_eq!(value.as_deref(), Some("from stdin\n"));
+    }
+
+    #[test]
+    fn resolve_text_input_reads_stdin_from_inline_dash() {
+        let value = resolve_text_input_with_reader(
+            "description",
+            &[InlineTextArg {
+                flag: "--message",
+                value: Some("-"),
+            }],
+            &[],
+            false,
+            true,
+            &mut Cursor::new("from stdin\n"),
+        )
+        .expect("stdin shorthand should resolve");
+
+        assert_eq!(value.as_deref(), Some("from stdin\n"));
+    }
+
+    #[test]
+    fn resolve_text_input_reads_design_file() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let design_path = dir.path().join("design.md");
+        fs::write(&design_path, "design doc\n").expect("write design");
+
+        let value = resolve_text_input_with_reader(
+            "design",
+            &[],
+            &[FileTextArg {
+                flag: "--design-file",
+                path: Some(design_path.as_path()),
+            }],
+            false,
+            false,
+            &mut Cursor::new(Vec::<u8>::new()),
+        )
+        .expect("design file should resolve");
+
+        assert_eq!(value.as_deref(), Some("design doc\n"));
+    }
+
+    #[test]
+    fn text_input_uses_stdin_detects_dash_sources() {
+        assert!(text_input_uses_stdin(
+            &[InlineTextArg {
+                flag: "--description",
+                value: Some("-"),
+            }],
+            &[FileTextArg {
+                flag: "--body-file",
+                path: Some(Path::new("-")),
+            }],
+            false,
+            true,
+        ));
+
+        assert!(!text_input_uses_stdin(
+            &[InlineTextArg {
+                flag: "--design",
+                value: Some("-"),
+            }],
+            &[],
+            false,
+            false,
+        ));
+    }
+}

--- a/crates/beads-cli/src/commands/list.rs
+++ b/crates/beads-cli/src/commands/list.rs
@@ -1,9 +1,10 @@
 use beads_api::QueryResult;
+use beads_core::BeadId;
 use beads_surface::Filters;
 use beads_surface::ipc::{ListPayload, Request, ResponsePayload};
 use clap::Args;
 
-use super::common::{fmt_issue_ref, fmt_labels};
+use super::common::{fmt_issue_ref, fmt_labels, fmt_wall_ms};
 use super::{CommandResult, print_ok};
 use crate::filters::{CommonFilterArgs, apply_common_filters};
 use crate::parsers::{parse_sort, parse_status};
@@ -14,6 +15,22 @@ use crate::validation::{normalize_bead_id_for, validation_error};
 pub struct ListArgs {
     #[command(flatten)]
     pub common: CommonFilterArgs,
+
+    /// Include closed beads instead of defaulting to open work.
+    #[arg(long)]
+    pub all: bool,
+
+    /// Show detailed multi-line output for each bead.
+    #[arg(long, conflicts_with_all = ["tree", "flat"])]
+    pub long: bool,
+
+    /// Render a hierarchical tree of descendants (requires --parent).
+    #[arg(long, conflicts_with = "flat")]
+    pub tree: bool,
+
+    /// Force the legacy flat list output.
+    #[arg(long, conflicts_with = "tree")]
+    pub flat: bool,
 
     /// Show labels in output.
     #[arg(short = 'L', long = "show-labels")]
@@ -51,8 +68,18 @@ pub fn handle_list(ctx: &CliRuntimeCtx, args: ListArgs) -> CommandResult<()> {
     let mut filters = Filters::default();
     apply_common_filters(&args.common, &mut filters)?;
 
+    if args.all && args.common.status.is_some() {
+        return Err(validation_error("all", "--all cannot be combined with --status").into());
+    }
+
     if let Some(status) = args.common.status.as_deref() {
         filters.status = Some(parse_status(status));
+    } else if args.all {
+        filters.status = Some(String::from("all"));
+    } else if ctx.json {
+        filters.status = None;
+    } else {
+        filters.status = Some(String::from("open"));
     }
 
     filters.limit = args.limit;
@@ -66,16 +93,35 @@ pub fn handle_list(ctx: &CliRuntimeCtx, args: ListArgs) -> CommandResult<()> {
         filters.ascending = ascending;
     }
 
+    let tree_parent = filters.parent.clone();
+    if !ctx.json && args.tree {
+        let Some(parent) = tree_parent.as_ref() else {
+            return Err(validation_error("tree", "--tree requires --parent").into());
+        };
+        let tree = fetch_child_tree(ctx, &filters, parent)?;
+        let output = render_issue_tree(parent.as_str(), &tree, args.show_labels);
+        crate::render::print_line(&output)?;
+        return Ok(());
+    }
+
     let req = Request::List {
         ctx: ctx.read_ctx(),
-        payload: ListPayload { filters },
+        payload: ListPayload {
+            filters: filters.clone(),
+        },
     };
     let ok = send(&req)?;
 
     if !ctx.json
         && let ResponsePayload::Query(QueryResult::Issues(ref views)) = ok
     {
-        let output = render_issue_list_opts(views, args.show_labels);
+        let output = if args.long {
+            render_issue_list_long(views, args.show_labels)
+        } else if args.flat {
+            render_issue_list_flat(views, args.show_labels)
+        } else {
+            render_issue_list_opts(views, args.show_labels)
+        };
         crate::render::print_line(&output)?;
         return Ok(());
     }
@@ -90,6 +136,10 @@ pub fn render_issue_list_opts(views: &[beads_api::IssueSummary], show_labels: bo
         out.push('\n');
     }
     out.trim_end().into()
+}
+
+fn render_issue_list_flat(views: &[beads_api::IssueSummary], show_labels: bool) -> String {
+    render_issue_list_opts(views, show_labels)
 }
 
 fn render_issue_summary_opts(view: &beads_api::IssueSummary, show_labels: bool) -> String {
@@ -110,6 +160,104 @@ fn render_issue_summary_opts(view: &beads_api::IssueSummary, show_labels: bool) 
     }
     summary.push_str(&format!(" - {}", view.title));
     summary
+}
+
+fn render_issue_list_long(views: &[beads_api::IssueSummary], show_labels: bool) -> String {
+    let mut out = String::new();
+    for (idx, view) in views.iter().enumerate() {
+        if idx > 0 {
+            out.push('\n');
+        }
+        out.push_str(&render_issue_summary_opts(view, show_labels));
+        if !view.description.trim().is_empty() {
+            out.push_str(&format!("\n  Description: {}", view.description.trim()));
+        }
+        if let Some(design) = &view.design
+            && !design.trim().is_empty()
+        {
+            out.push_str(&format!("\n  Design: {}", design.trim()));
+        }
+        if let Some(acceptance) = &view.acceptance_criteria
+            && !acceptance.trim().is_empty()
+        {
+            out.push_str(&format!("\n  Acceptance: {}", acceptance.trim()));
+        }
+        out.push_str(&format!(
+            "\n  Updated: {}",
+            fmt_wall_ms(view.updated_at.wall_ms)
+        ));
+    }
+    out
+}
+
+#[derive(Clone)]
+struct TreeNode {
+    issue: beads_api::IssueSummary,
+    children: Vec<TreeNode>,
+}
+
+fn fetch_child_tree(
+    ctx: &CliRuntimeCtx,
+    base_filters: &Filters,
+    parent: &BeadId,
+) -> CommandResult<Vec<TreeNode>> {
+    let mut filters = base_filters.clone();
+    filters.parent = Some(parent.clone());
+    let children = list_issue_summaries(ctx, filters)?;
+
+    let mut nodes = Vec::with_capacity(children.len());
+    for child in children {
+        let child_id = BeadId::parse(&child.id)?;
+        let descendants = fetch_child_tree(ctx, base_filters, &child_id)?;
+        nodes.push(TreeNode {
+            issue: child,
+            children: descendants,
+        });
+    }
+    Ok(nodes)
+}
+
+fn list_issue_summaries(
+    ctx: &CliRuntimeCtx,
+    filters: Filters,
+) -> CommandResult<Vec<beads_api::IssueSummary>> {
+    let req = Request::List {
+        ctx: ctx.read_ctx(),
+        payload: ListPayload { filters },
+    };
+    match send(&req)? {
+        ResponsePayload::Query(QueryResult::Issues(views)) => Ok(views),
+        other => Err(validation_error(
+            "list",
+            format!("unexpected response while building tree view: {other:?}"),
+        )
+        .into()),
+    }
+}
+
+fn render_issue_tree(parent: &str, nodes: &[TreeNode], show_labels: bool) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("Children of {parent}:\n"));
+    if nodes.is_empty() {
+        out.push_str("  (none)");
+        return out;
+    }
+    for node in nodes {
+        render_tree_node(&mut out, node, show_labels, 0);
+    }
+    out.trim_end().to_string()
+}
+
+fn render_tree_node(out: &mut String, node: &TreeNode, show_labels: bool, depth: usize) {
+    let indent = "  ".repeat(depth);
+    out.push_str(&format!(
+        "{}- {}\n",
+        indent,
+        render_issue_summary_opts(&node.issue, show_labels)
+    ));
+    for child in &node.children {
+        render_tree_node(out, child, show_labels, depth + 1);
+    }
 }
 
 #[cfg(test)]
@@ -146,5 +294,29 @@ mod tests {
         let summary = sample_summary("wf", "bd-123");
         let output = render_issue_list_opts(&[summary], false);
         assert_eq!(output, "wf/bd-123 [P1] [task] open - Title");
+    }
+
+    #[test]
+    fn render_issue_list_long_includes_description() {
+        let mut summary = sample_summary("core", "bd-123");
+        summary.description = "Detailed description".to_string();
+        let output = render_issue_list_long(&[summary], false);
+        assert!(output.contains("bd-123 [P1] [task] open - Title"));
+        assert!(output.contains("Description: Detailed description"));
+    }
+
+    #[test]
+    fn render_issue_tree_indents_nested_children() {
+        let child = TreeNode {
+            issue: sample_summary("core", "bd-123.1"),
+            children: vec![TreeNode {
+                issue: sample_summary("core", "bd-123.1.1"),
+                children: Vec::new(),
+            }],
+        };
+        let output = render_issue_tree("bd-123", &[child], false);
+        assert!(output.contains("Children of bd-123:"));
+        assert!(output.contains("- core/bd-123.1 [P1] [task] open - Title"));
+        assert!(output.contains("  - core/bd-123.1.1 [P1] [task] open - Title"));
     }
 }

--- a/crates/beads-cli/src/commands/mod.rs
+++ b/crates/beads-cli/src/commands/mod.rs
@@ -23,6 +23,7 @@ pub mod deleted;
 pub mod dep;
 pub mod epic;
 pub mod init;
+pub mod input;
 pub mod label;
 pub mod list;
 pub mod migrate;

--- a/crates/beads-cli/src/commands/prime.rs
+++ b/crates/beads-cli/src/commands/prime.rs
@@ -1,21 +1,91 @@
+use clap::Args;
 use std::io::Write;
+use std::path::{Path, PathBuf};
+
+const LOCAL_AGENT_MARKERS: &[&str] = &[
+    ".aider.conf.yml",
+    ".cursor/rules/beads.mdc",
+    ".codex/AGENTS.md",
+    ".gemini/GEMINI.md",
+    ".opencode/AGENTS.md",
+    ".windsurf/rules/beads.md",
+];
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct PrimeArgs {
+    /// Force full CLI context output.
+    #[arg(long, conflicts_with = "mcp")]
+    pub full: bool,
+
+    /// Force compact MCP/editor-hook output.
+    #[arg(long, conflicts_with = "full")]
+    pub mcp: bool,
+
+    /// Prefer a no-git close protocol for agent sessions.
+    #[arg(long)]
+    pub stealth: bool,
+
+    /// Output the built-in default content and ignore PRIME.md overrides.
+    #[arg(long)]
+    pub export: bool,
+}
 
 /// Output workflow context when the caller is in a beads repository.
 ///
 /// Callers are responsible for determining repo status and handling
 /// broken-pipe behavior appropriate for their process boundary.
-pub fn write_context_if<W: Write>(out: &mut W, in_beads_repo: bool) -> std::io::Result<()> {
+pub fn write_context_if<W: Write>(
+    out: &mut W,
+    in_beads_repo: bool,
+    args: &PrimeArgs,
+) -> std::io::Result<()> {
     if !in_beads_repo {
         return Ok(());
     }
-    write!(out, "{}", context())
+
+    if !args.export
+        && let Some(override_path) = resolve_override_path(Path::new(".beads/PRIME.md"))
+        && let Ok(content) = std::fs::read_to_string(override_path)
+    {
+        return write!(out, "{content}");
+    }
+
+    write!(out, "{}", render_context(args))
 }
 
-pub fn context() -> &'static str {
-    r#"# Beads Workflow
+pub fn render_context(args: &PrimeArgs) -> String {
+    let mode = if args.mcp {
+        PrimeMode::Mcp
+    } else if args.full {
+        PrimeMode::Full
+    } else if is_mcp_active() {
+        PrimeMode::Mcp
+    } else {
+        PrimeMode::Full
+    };
+
+    match mode {
+        PrimeMode::Full => full_context(args.stealth),
+        PrimeMode::Mcp => mcp_context(args.stealth),
+    }
+}
+
+fn full_context(stealth: bool) -> String {
+    let close_protocol = if stealth {
+        "Before saying done: summarize what changed, run the required verification, and leave git push/manual publish decisions to the user."
+    } else {
+        "Before saying done: summarize what changed, run the required verification, and handle the normal local jj/git workflow for this repo."
+    };
+
+    format!(
+        r#"# Beads Workflow
 
 Track ALL work in beads. No TodoWrite, no markdown TODOs.
 Sync is automatic (~500ms). Run `bd prime` after context compaction.
+
+## Session Close
+
+{}
 
 ## Finding Work
 
@@ -93,7 +163,89 @@ Type + priority + status covers most organization. Labels are for cross-cutting 
 ```bash
 bd label add <id> tech-debt
 ```
-"#
+"#,
+        close_protocol
+    )
+}
+
+fn mcp_context(stealth: bool) -> String {
+    let close_protocol = if stealth {
+        "Close protocol: verify and summarize only; do not assume git operations."
+    } else {
+        "Close protocol: verify, summarize, and follow the repo's normal jj/git rhythm."
+    };
+
+    format!(
+        r#"# Beads Workflow
+
+- Track all work in `bd`, not markdown TODOs.
+- Start with `bd ready`, inspect with `bd show <id>`, and create follow-up work with `bd create`.
+- Sync is automatic; rerun `bd prime` after context compaction.
+- Use `bd help` for grouped command discovery and `bd help --advanced <cmd>` for transport flags.
+- {}
+"#,
+        close_protocol
+    )
+}
+
+fn resolve_override_path(local_override: &Path) -> Option<PathBuf> {
+    if local_override.exists() {
+        return Some(local_override.to_path_buf());
+    }
+
+    let global_override = dirs::config_dir()?.join("beads/PRIME.md");
+    if global_override.exists() {
+        return Some(global_override);
+    }
+    None
+}
+
+fn is_mcp_active() -> bool {
+    let cwd = std::env::current_dir().ok();
+    let home = dirs::home_dir().or_else(|| std::env::var_os("HOME").map(PathBuf::from));
+    is_mcp_active_in(cwd.as_deref(), home.as_deref())
+}
+
+fn is_mcp_active_in(cwd: Option<&Path>, home: Option<&Path>) -> bool {
+    if let Some(cwd) = cwd {
+        if LOCAL_AGENT_MARKERS
+            .iter()
+            .any(|marker| cwd.join(marker).exists())
+        {
+            return true;
+        }
+        if claude_settings_has_beads_server(cwd.join(".claude/settings.local.json")) {
+            return true;
+        }
+    }
+
+    let Some(home) = home else {
+        return false;
+    };
+    claude_settings_has_beads_server(home.join(".claude/settings.json"))
+}
+
+fn claude_settings_has_beads_server(path: PathBuf) -> bool {
+    let Ok(data) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&data) else {
+        return false;
+    };
+    let Some(servers) = value
+        .get("mcpServers")
+        .and_then(|servers| servers.as_object())
+    else {
+        return false;
+    };
+    servers
+        .keys()
+        .any(|key| key.to_ascii_lowercase().contains("beads"))
+}
+
+enum PrimeMode {
+    Full,
+    Mcp,
 }
 
 #[cfg(test)]
@@ -101,8 +253,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn context_is_not_empty() {
-        let ctx = context();
+    fn full_context_is_not_empty() {
+        let ctx = render_context(&PrimeArgs {
+            full: true,
+            ..PrimeArgs::default()
+        });
         assert!(!ctx.is_empty());
         assert!(ctx.contains("Beads Workflow"));
         assert!(ctx.contains("bd ready"));
@@ -112,15 +267,60 @@ mod tests {
     #[test]
     fn write_context_if_is_silent_outside_beads_repo() {
         let mut out = Vec::new();
-        write_context_if(&mut out, false).expect("write");
+        write_context_if(&mut out, false, &PrimeArgs::default()).expect("write");
         assert!(out.is_empty());
     }
 
     #[test]
     fn write_context_if_outputs_context_in_beads_repo() {
         let mut out = Vec::new();
-        write_context_if(&mut out, true).expect("write");
+        let args = PrimeArgs {
+            full: true,
+            ..PrimeArgs::default()
+        };
+        write_context_if(&mut out, true, &args).expect("write");
         let rendered = String::from_utf8(out).expect("utf8");
-        assert_eq!(rendered, context());
+        assert_eq!(rendered, render_context(&args));
+    }
+
+    #[test]
+    fn mcp_context_is_compact() {
+        let rendered = render_context(&PrimeArgs {
+            mcp: true,
+            ..PrimeArgs::default()
+        });
+        assert!(rendered.contains("Close protocol:"));
+        assert!(rendered.contains("bd ready"));
+    }
+
+    #[test]
+    fn resolve_override_path_prefers_local_file() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let local = dir.path().join("PRIME.md");
+        std::fs::write(&local, "local").expect("write local");
+        let resolved = resolve_override_path(&local).expect("override");
+        assert_eq!(resolved, local);
+    }
+
+    #[test]
+    fn mcp_detection_recognizes_local_editor_markers() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let marker = dir.path().join(".codex/AGENTS.md");
+        std::fs::create_dir_all(marker.parent().expect("parent")).expect("mkdirs");
+        std::fs::write(&marker, "beads").expect("write marker");
+        assert!(is_mcp_active_in(Some(dir.path()), None));
+    }
+
+    #[test]
+    fn mcp_detection_recognizes_project_claude_settings() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let settings = dir.path().join(".claude/settings.local.json");
+        std::fs::create_dir_all(settings.parent().expect("parent")).expect("mkdirs");
+        std::fs::write(
+            &settings,
+            r#"{"mcpServers":{"beads":{"command":"bd","args":["mcp","serve"]}}}"#,
+        )
+        .expect("write settings");
+        assert!(is_mcp_active_in(Some(dir.path()), None));
     }
 }

--- a/crates/beads-cli/src/commands/setup.rs
+++ b/crates/beads-cli/src/commands/setup.rs
@@ -4,6 +4,7 @@
 //! - `bd setup claude` - Claude Code hooks
 //! - `bd setup cursor` - Cursor IDE rules
 //! - `bd setup aider` - Aider configuration
+//! - `bd setup codex|gemini|opencode|windsurf` - Additional file-based recipes
 
 use std::fs;
 use std::io::Write;
@@ -24,12 +25,22 @@ pub enum SetupError {
 
 #[derive(Subcommand, Debug)]
 pub enum SetupCmd {
+    /// List the supported setup recipes.
+    List,
     /// Setup Claude Code integration (hooks for SessionStart/PreCompact).
     Claude(SetupClaudeArgs),
     /// Setup Cursor IDE integration (rules file).
-    Cursor(SetupCursorArgs),
+    Cursor(SetupRecipeArgs),
     /// Setup Aider integration (config + instructions).
-    Aider(SetupAiderArgs),
+    Aider(SetupRecipeArgs),
+    /// Setup Codex integration (project-local AGENTS.md).
+    Codex(SetupRecipeArgs),
+    /// Setup Gemini integration (project-local instructions).
+    Gemini(SetupRecipeArgs),
+    /// Setup OpenCode integration (project-local AGENTS.md).
+    OpenCode(SetupRecipeArgs),
+    /// Setup Windsurf integration (rules file).
+    Windsurf(SetupRecipeArgs),
 }
 
 #[derive(Args, Debug)]
@@ -47,24 +58,13 @@ pub struct SetupClaudeArgs {
     pub remove: bool,
 }
 
-#[derive(Args, Debug)]
-pub struct SetupCursorArgs {
-    /// Check if Cursor integration is installed.
+#[derive(Args, Debug, Clone, Copy)]
+pub struct SetupRecipeArgs {
+    /// Check if the integration is installed.
     #[arg(long)]
     pub check: bool,
 
-    /// Remove bd rules from Cursor.
-    #[arg(long)]
-    pub remove: bool,
-}
-
-#[derive(Args, Debug)]
-pub struct SetupAiderArgs {
-    /// Check if Aider integration is installed.
-    #[arg(long)]
-    pub check: bool,
-
-    /// Remove bd config from Aider.
+    /// Remove the integration files.
     #[arg(long)]
     pub remove: bool,
 }
@@ -72,6 +72,14 @@ pub struct SetupAiderArgs {
 // =============================================================================
 // Claude Code integration
 // =============================================================================
+
+#[derive(Clone, Copy)]
+struct FileRecipe {
+    name: &'static str,
+    description: &'static str,
+    path: &'static str,
+    contents: &'static str,
+}
 
 pub fn handle_claude(project: bool, check: bool, remove: bool) -> Result<()> {
     if check {
@@ -675,6 +683,73 @@ fn remove_aider() -> Result<()> {
     Ok(())
 }
 
+const CODEX_INSTRUCTIONS: &str = r#"# Beads Workflow for Codex
+
+This repository tracks work in `bd`.
+
+- Use `bd ready` to find unblocked work.
+- Use `bd show <id>` to inspect a bead in detail.
+- Use `bd create` to capture newly discovered work.
+- Use `bd prime` whenever you need the full workflow context refreshed.
+"#;
+
+const GEMINI_INSTRUCTIONS: &str = r#"# Beads Workflow for Gemini
+
+Use `bd` for all task tracking in this repository.
+
+- Start with `bd ready`.
+- Inspect with `bd show <id>`.
+- Capture new work with `bd create`.
+- Reload context with `bd prime`.
+"#;
+
+const OPENCODE_INSTRUCTIONS: &str = r#"# Beads Workflow for OpenCode
+
+This repository uses `bd` as the source of truth for work tracking.
+
+- `bd ready` surfaces unblocked work.
+- `bd list --all` shows the broader backlog.
+- `bd show <id>` gives full context for one bead.
+- `bd prime --mcp` provides a compact agent-facing refresher.
+"#;
+
+const WINDSURF_RULES: &str = r#"# Beads Workflow
+
+Track all work in `bd`.
+
+- Use `bd ready` before starting work.
+- Use `bd create` for newly discovered work.
+- Use `bd show <id>` for details.
+- Use `bd prime` for a full workflow refresher.
+"#;
+
+const FILE_RECIPES: &[FileRecipe] = &[
+    FileRecipe {
+        name: "codex",
+        description: "Project-local Codex instructions",
+        path: ".codex/AGENTS.md",
+        contents: CODEX_INSTRUCTIONS,
+    },
+    FileRecipe {
+        name: "gemini",
+        description: "Project-local Gemini instructions",
+        path: ".gemini/GEMINI.md",
+        contents: GEMINI_INSTRUCTIONS,
+    },
+    FileRecipe {
+        name: "opencode",
+        description: "Project-local OpenCode instructions",
+        path: ".opencode/AGENTS.md",
+        contents: OPENCODE_INSTRUCTIONS,
+    },
+    FileRecipe {
+        name: "windsurf",
+        description: "Project-local Windsurf rules",
+        path: ".windsurf/rules/beads.md",
+        contents: WINDSURF_RULES,
+    },
+];
+
 // =============================================================================
 // Helpers
 // =============================================================================
@@ -716,6 +791,90 @@ fn atomic_write(path: &Path, data: &[u8]) -> Result<()> {
     fs::rename(&temp_path, path)
         .map_err(|e| validation_error("setup", format!("failed to rename file: {e}")))?;
 
+    Ok(())
+}
+
+pub fn handle_setup_list() -> Result<()> {
+    print_line("Supported setup recipes:")?;
+    print_line("  claude    Claude Code hooks (global or project)")?;
+    print_line("  cursor    Cursor rules file")?;
+    print_line("  aider     Aider config + instructions")?;
+    for recipe in FILE_RECIPES {
+        print_line(&format!("  {:<9} {}", recipe.name, recipe.description))?;
+    }
+    Ok(())
+}
+
+pub fn handle_file_recipe(name: &str, args: SetupRecipeArgs) -> Result<()> {
+    let recipe = FILE_RECIPES
+        .iter()
+        .find(|recipe| recipe.name == name)
+        .ok_or_else(|| validation_error("setup", format!("unknown setup recipe {name}")))?;
+
+    if args.check {
+        return check_file_recipe(recipe);
+    }
+    if args.remove {
+        return remove_file_recipe(recipe);
+    }
+    install_file_recipe(recipe)
+}
+
+fn install_file_recipe(recipe: &FileRecipe) -> Result<()> {
+    let path = PathBuf::from(recipe.path);
+    print_line(&format!("Installing {} integration...", recipe.name))?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            validation_error("setup", format!("failed to create directory: {err}"))
+        })?;
+    }
+    atomic_write(&path, recipe.contents.as_bytes())?;
+    print_line("")?;
+    print_line(&format!("✓ {} integration installed", recipe.name))?;
+    print_line(&format!("  File: {}", path.display()))?;
+    Ok(())
+}
+
+fn check_file_recipe(recipe: &FileRecipe) -> Result<()> {
+    let cwd = std::env::current_dir()
+        .map_err(|err| validation_error("setup", format!("failed to resolve cwd: {err}")))?;
+    check_file_recipe_at(recipe, &cwd)
+}
+
+fn check_file_recipe_at(recipe: &FileRecipe, base_dir: &Path) -> Result<()> {
+    let path = base_dir.join(recipe.path);
+    if path.exists() {
+        print_line(&format!(
+            "✓ {} integration installed: {}",
+            recipe.name,
+            path.display()
+        ))?;
+        Ok(())
+    } else {
+        print_line(&format!("✗ {} integration not installed", recipe.name))?;
+        print_line(&format!("  Run: bd setup {}", recipe.name))?;
+        Err(validation_error(
+            "setup",
+            format!("{} integration not installed", recipe.name),
+        ))
+    }
+}
+
+fn remove_file_recipe(recipe: &FileRecipe) -> Result<()> {
+    let path = PathBuf::from(recipe.path);
+    print_line(&format!("Removing {} integration...", recipe.name))?;
+    match fs::remove_file(&path) {
+        Ok(_) => print_line(&format!("✓ Removed {} integration", recipe.name))?,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            print_line("No integration file found")?;
+        }
+        Err(err) => {
+            return Err(validation_error(
+                "setup",
+                format!("failed to remove file: {err}"),
+            ));
+        }
+    }
     Ok(())
 }
 
@@ -823,5 +982,30 @@ mod tests {
         // Remove again
         let removed = remove_hook_command(&mut hooks, event, command);
         assert!(!removed);
+    }
+
+    #[test]
+    fn setup_list_mentions_new_recipes() {
+        let names = FILE_RECIPES
+            .iter()
+            .map(|recipe| recipe.name)
+            .collect::<Vec<_>>();
+        assert!(names.contains(&"codex"));
+        assert!(names.contains(&"gemini"));
+        assert!(names.contains(&"opencode"));
+        assert!(names.contains(&"windsurf"));
+    }
+
+    #[test]
+    fn generic_recipe_check_fails_when_missing() {
+        let recipe = FileRecipe {
+            name: "codex",
+            description: "Project-local Codex instructions",
+            path: ".codex/AGENTS.md",
+            contents: CODEX_INSTRUCTIONS,
+        };
+        let dir = tempdir().expect("temp dir");
+        let err = check_file_recipe_at(&recipe, dir.path()).expect_err("expected missing recipe");
+        assert!(matches!(err, SetupError::Validation { .. }));
     }
 }

--- a/crates/beads-cli/src/commands/show.rs
+++ b/crates/beads-cli/src/commands/show.rs
@@ -1,120 +1,124 @@
 use clap::Args;
 
 use super::common::{fmt_issue_ref, fmt_labels, fmt_wall_ms};
-use super::{CommandResult, print_ok};
-use crate::render::print_line;
+use super::{CommandError, CommandResult, print_ok};
+use crate::render::{print_json, print_line};
 use crate::runtime::{CliRuntimeCtx, send};
-use crate::validation::normalize_bead_id;
+use crate::validation::{normalize_bead_id, validation_error};
 use beads_api::{Issue, IssueSummary, Note, QueryResult};
-use beads_core::{BeadId, BeadType, WorkflowStatus};
-use beads_surface::Filters;
+use beads_core::{BeadId, BeadType, NamespaceId, WorkflowStatus};
 use beads_surface::ipc::{IdPayload, ListPayload, Request, ResponsePayload};
+use beads_surface::{Filters, SortField};
 use std::collections::{BTreeSet, HashMap};
+use std::path::Path;
+use std::process::Command as ProcessCommand;
 
 #[derive(Args, Debug)]
 pub struct ShowArgs {
-    pub id: String,
+    /// Bead id(s) to inspect.
+    #[arg(value_name = "ID", num_args = 0..)]
+    pub id: Vec<String>,
 
-    /// No-op for compatibility (children are always shown).
-    #[arg(long, hide = true)]
+    /// Bead id to inspect, useful when the id could be mistaken for a flag.
+    #[arg(long = "id", value_name = "ID", num_args = 1..)]
+    pub id_flag: Vec<String>,
+
+    /// Resolve the current bead from the active jj change or your most recent in-progress work.
+    #[arg(long)]
+    pub current: bool,
+
+    /// Compact one-line output.
+    #[arg(long, conflicts_with = "long")]
+    pub short: bool,
+
+    /// Full output including dependency and comment sections.
+    #[arg(long, conflicts_with = "short")]
+    pub long: bool,
+
+    /// Show only incoming references to the bead.
+    #[arg(long, conflicts_with = "children")]
+    pub refs: bool,
+
+    /// Show only direct children of the bead.
+    #[arg(long)]
     pub children: bool,
 }
 
 pub fn handle(ctx: &CliRuntimeCtx, args: ShowArgs) -> CommandResult<()> {
-    let id = normalize_bead_id(&args.id)?;
-    if ctx.json {
-        let req = Request::ShowDetails {
-            ctx: ctx.read_ctx(),
-            payload: IdPayload { id: id.clone() },
-        };
-        let ok = send(&req)?;
-        return match ok {
-            ResponsePayload::Query(QueryResult::ShowDetails(details)) => print_ok(
-                &ResponsePayload::Query(QueryResult::Issue(details.issue)),
-                true,
-            ),
-            other => print_ok(&other, true),
-        };
+    let ids = resolve_show_ids(ctx, args.id, args.id_flag, args.current)?;
+    let mut views = Vec::with_capacity(ids.len());
+    for id in &ids {
+        views.push(fetch_show_view(ctx, id)?);
     }
 
+    if ctx.json {
+        let issues = views
+            .iter()
+            .map(|view| view.issue.clone())
+            .collect::<Vec<_>>();
+        if issues.len() == 1 {
+            return print_ok(
+                &ResponsePayload::Query(QueryResult::Issue(
+                    issues.into_iter().next().expect("single issue"),
+                )),
+                true,
+            );
+        }
+        print_json(&issues)?;
+        return Ok(());
+    }
+
+    let mut output = String::new();
+    for (idx, view) in views.iter().enumerate() {
+        if idx > 0 && !args.short {
+            output.push_str("\n------------------------------------------------------------\n");
+        }
+        let rendered = if args.refs {
+            render_show_refs(&view.issue, &view.incoming, args.short)
+        } else if args.children {
+            render_show_children(&view.issue, &view.incoming.children, args.short)
+        } else if args.short {
+            render_issue_summary(&view.issue)
+        } else if args.long {
+            render_show_long(&view.issue, &view.outgoing, &view.incoming, &view.notes)
+        } else {
+            render_show(&view.issue, &view.outgoing, &view.incoming, &view.notes)
+        };
+        output.push_str(rendered.trim_end());
+        output.push('\n');
+    }
+
+    print_line(output.trim_end())?;
+    Ok(())
+}
+
+fn fetch_show_view(ctx: &CliRuntimeCtx, id: &BeadId) -> CommandResult<ShowView> {
     let req = Request::ShowDetails {
         ctx: ctx.read_ctx(),
         payload: IdPayload { id: id.clone() },
     };
     match send(&req)? {
-        ResponsePayload::Query(QueryResult::ShowDetails(details)) => {
-            let mut summary_map: HashMap<String, IssueSummary> = details
-                .summaries
-                .into_iter()
-                .map(|summary| (summary.id.clone(), summary))
-                .collect();
-
-            let outgoing_edges = details.outgoing;
-            let incoming_edges = details.incoming;
-            let notes = details.issue.notes.clone();
-            let view = details.issue;
-
-            let outgoing_ids: BTreeSet<String> =
-                outgoing_edges.iter().map(|e| e.to.clone()).collect();
-
-            let mut blocks_ids: BTreeSet<String> = BTreeSet::new();
-            let mut children_ids: BTreeSet<String> = BTreeSet::new();
-            let mut related_ids: BTreeSet<String> = BTreeSet::new();
-            let mut discovered_ids: BTreeSet<String> = BTreeSet::new();
-            for e in &incoming_edges {
-                match e.kind.as_str() {
-                    "parent" => {
-                        children_ids.insert(e.from.clone());
-                    }
-                    "related" => {
-                        related_ids.insert(e.from.clone());
-                    }
-                    "discovered_from" => {
-                        discovered_ids.insert(e.from.clone());
-                    }
-                    _ => {
-                        blocks_ids.insert(e.from.clone());
-                    }
-                }
-            }
-
-            let mut all_ids = BTreeSet::new();
-            all_ids.extend(outgoing_ids.iter().cloned());
-            all_ids.extend(blocks_ids.iter().cloned());
-            all_ids.extend(children_ids.iter().cloned());
-            all_ids.extend(related_ids.iter().cloned());
-            all_ids.extend(discovered_ids.iter().cloned());
-
-            let has_all_summaries = all_ids
-                .iter()
-                .all(|dep_id| summary_map.contains_key(dep_id));
-            if !has_all_summaries {
-                let fetched = fetch_summary_map(ctx, &all_ids)?;
-                summary_map.extend(fetched);
-            }
-
-            let outgoing_views = summaries_for(&outgoing_ids, &summary_map);
-            let blocks = summaries_for(&blocks_ids, &summary_map);
-            let children = summaries_for(&children_ids, &summary_map);
-            let related = summaries_for(&related_ids, &summary_map);
-            let discovered = summaries_for(&discovered_ids, &summary_map);
-
-            let incoming = IncomingGroups {
-                children,
-                blocks,
-                related,
-                discovered,
-            };
-
-            print_line(&render_show(&view, &outgoing_views, &incoming, &notes))?;
-            Ok(())
-        }
-        ResponsePayload::Query(QueryResult::Issue(view)) => render_show_legacy(ctx, &id, view),
-        other => print_ok(&other, false),
+        ResponsePayload::Query(QueryResult::ShowDetails(details)) => build_show_view(
+            ctx,
+            details.issue,
+            details.incoming,
+            details.outgoing,
+            details.summaries,
+        ),
+        ResponsePayload::Query(QueryResult::Issue(view)) => fetch_show_view_legacy(ctx, id, view),
+        other => Err(CommandError::Ipc(
+            beads_surface::ipc::IpcError::DaemonUnavailable(format!(
+                "unexpected response for show details: {other:?}"
+            )),
+        )),
     }
 }
 
-fn render_show_legacy(ctx: &CliRuntimeCtx, id: &BeadId, view: Issue) -> CommandResult<()> {
+fn fetch_show_view_legacy(
+    ctx: &CliRuntimeCtx,
+    id: &BeadId,
+    view: Issue,
+) -> CommandResult<ShowView> {
     let deps_payload = send(&Request::Deps {
         ctx: ctx.read_ctx(),
         payload: IdPayload { id: id.clone() },
@@ -123,7 +127,6 @@ fn render_show_legacy(ctx: &CliRuntimeCtx, id: &BeadId, view: Issue) -> CommandR
         ResponsePayload::Query(QueryResult::Deps { incoming, outgoing }) => (incoming, outgoing),
         _ => (Vec::new(), Vec::new()),
     };
-
     let notes_payload = send(&Request::Notes {
         ctx: ctx.read_ctx(),
         payload: IdPayload { id: id.clone() },
@@ -132,9 +135,22 @@ fn render_show_legacy(ctx: &CliRuntimeCtx, id: &BeadId, view: Issue) -> CommandR
         ResponsePayload::Query(QueryResult::Notes(n)) => n,
         _ => Vec::new(),
     };
+    let show_view = build_show_view(ctx, view, incoming_edges, outgoing_edges, Vec::new())?;
+    Ok(ShowView { notes, ..show_view })
+}
 
+fn build_show_view(
+    ctx: &CliRuntimeCtx,
+    view: Issue,
+    incoming_edges: Vec<beads_api::DepEdge>,
+    outgoing_edges: Vec<beads_api::DepEdge>,
+    summaries: Vec<IssueSummary>,
+) -> CommandResult<ShowView> {
+    let mut summary_map: HashMap<String, IssueSummary> = summaries
+        .into_iter()
+        .map(|summary| (summary.id.clone(), summary))
+        .collect();
     let outgoing_ids: BTreeSet<String> = outgoing_edges.iter().map(|e| e.to.clone()).collect();
-
     let mut blocks_ids: BTreeSet<String> = BTreeSet::new();
     let mut children_ids: BTreeSet<String> = BTreeSet::new();
     let mut related_ids: BTreeSet<String> = BTreeSet::new();
@@ -162,7 +178,12 @@ fn render_show_legacy(ctx: &CliRuntimeCtx, id: &BeadId, view: Issue) -> CommandR
     all_ids.extend(children_ids.iter().cloned());
     all_ids.extend(related_ids.iter().cloned());
     all_ids.extend(discovered_ids.iter().cloned());
-    let summary_map = fetch_summary_map(ctx, &all_ids)?;
+    let has_all_summaries = all_ids
+        .iter()
+        .all(|dep_id| summary_map.contains_key(dep_id));
+    if !has_all_summaries {
+        summary_map.extend(fetch_summary_map(ctx, &all_ids)?);
+    }
 
     let outgoing_views = summaries_for(&outgoing_ids, &summary_map);
     let blocks = summaries_for(&blocks_ids, &summary_map);
@@ -177,8 +198,46 @@ fn render_show_legacy(ctx: &CliRuntimeCtx, id: &BeadId, view: Issue) -> CommandR
         discovered,
     };
 
-    print_line(&render_show(&view, &outgoing_views, &incoming, &notes))?;
-    Ok(())
+    let notes = view.notes.clone();
+    Ok(ShowView {
+        issue: view,
+        outgoing: outgoing_views,
+        incoming,
+        notes,
+    })
+}
+
+fn resolve_show_ids(
+    ctx: &CliRuntimeCtx,
+    positional: Vec<String>,
+    id_flag: Vec<String>,
+    current: bool,
+) -> CommandResult<Vec<BeadId>> {
+    if current && (!positional.is_empty() || !id_flag.is_empty()) {
+        return Err(validation_error(
+            "current",
+            "--current cannot be combined with explicit bead ids",
+        )
+        .into());
+    }
+
+    if current {
+        return Ok(vec![resolve_current_issue_id(ctx)?]);
+    }
+
+    let raw_ids = positional.into_iter().chain(id_flag).collect::<Vec<_>>();
+    if raw_ids.is_empty() {
+        return Err(validation_error(
+            "id",
+            "show requires at least one bead id (or use --current)",
+        )
+        .into());
+    }
+
+    raw_ids
+        .into_iter()
+        .map(|raw| normalize_bead_id(&raw).map_err(Into::into))
+        .collect()
 }
 
 fn fetch_summary_map(
@@ -225,6 +284,13 @@ pub struct IncomingGroups {
     pub discovered: Vec<IssueSummary>,
 }
 
+struct ShowView {
+    issue: Issue,
+    outgoing: Vec<IssueSummary>,
+    incoming: IncomingGroups,
+    notes: Vec<Note>,
+}
+
 fn render_show(
     bead: &Issue,
     outgoing: &[IssueSummary],
@@ -234,10 +300,12 @@ fn render_show(
     let mut out = String::new();
     out.push_str(&format!(
         "\n{}: {}\n",
-        fmt_issue_ref(&bead.namespace, &bead.id),
+        fmt_show_issue_ref(&bead.namespace, &bead.id),
         bead.title
     ));
-    out.push_str(&format!("Namespace: {}\n", bead.namespace.as_str()));
+    if bead.namespace != NamespaceId::core() {
+        out.push_str(&format!("Namespace: {}\n", bead.namespace.as_str()));
+    }
     out.push_str(&format!("Status: {}\n", bead.status.as_str()));
     out.push_str(&format!("Priority: P{}\n", bead.priority));
     out.push_str(&format!("Type: {}\n", bead.issue_type.as_str()));
@@ -278,7 +346,7 @@ fn render_show(
         for dep in outgoing {
             out.push_str(&format!(
                 "  → {}: {} [P{}]\n",
-                fmt_issue_ref(&dep.namespace, &dep.id),
+                fmt_show_issue_ref(&dep.namespace, &dep.id),
                 dep.title,
                 dep.priority
             ));
@@ -294,7 +362,7 @@ fn render_show(
             for dep in &incoming.children {
                 out.push_str(&format!(
                     "  ↳ {}: {} [P{}]\n",
-                    fmt_issue_ref(&dep.namespace, &dep.id),
+                    fmt_show_issue_ref(&dep.namespace, &dep.id),
                     dep.title,
                     dep.priority
                 ));
@@ -306,7 +374,7 @@ fn render_show(
         for dep in &incoming.blocks {
             out.push_str(&format!(
                 "  ← {}: {} [P{}]\n",
-                fmt_issue_ref(&dep.namespace, &dep.id),
+                fmt_show_issue_ref(&dep.namespace, &dep.id),
                 dep.title,
                 dep.priority
             ));
@@ -317,7 +385,7 @@ fn render_show(
         for dep in &incoming.related {
             out.push_str(&format!(
                 "  ↔ {}: {} [P{}]\n",
-                fmt_issue_ref(&dep.namespace, &dep.id),
+                fmt_show_issue_ref(&dep.namespace, &dep.id),
                 dep.title,
                 dep.priority
             ));
@@ -328,7 +396,7 @@ fn render_show(
         for dep in &incoming.discovered {
             out.push_str(&format!(
                 "  ◊ {}: {} [P{}]\n",
-                fmt_issue_ref(&dep.namespace, &dep.id),
+                fmt_show_issue_ref(&dep.namespace, &dep.id),
                 dep.title,
                 dep.priority
             ));
@@ -351,15 +419,26 @@ fn render_show(
     out
 }
 
+fn render_show_long(
+    bead: &Issue,
+    outgoing: &[IssueSummary],
+    incoming: &IncomingGroups,
+    notes: &[Note],
+) -> String {
+    render_show(bead, outgoing, incoming, notes)
+}
+
 pub fn render_issue_detail(v: &Issue) -> String {
     // Default detail renderer (used for `show --json=false` fallback).
     let mut out = String::new();
     out.push_str(&format!(
         "\n{}: {}\n",
-        fmt_issue_ref(&v.namespace, &v.id),
+        fmt_show_issue_ref(&v.namespace, &v.id),
         v.title
     ));
-    out.push_str(&format!("Namespace: {}\n", v.namespace.as_str()));
+    if v.namespace != NamespaceId::core() {
+        out.push_str(&format!("Namespace: {}\n", v.namespace.as_str()));
+    }
     out.push_str(&format!("Status: {}\n", v.status.as_str()));
     out.push_str(&format!("Priority: P{}\n", v.priority));
     out.push_str(&format!("Type: {}\n", v.issue_type.as_str()));
@@ -400,6 +479,130 @@ pub fn render_issue_detail(v: &Issue) -> String {
     }
     out.push('\n');
     out
+}
+
+fn render_issue_summary(v: &Issue) -> String {
+    let assignee = v
+        .assignee
+        .as_ref()
+        .filter(|assignee| !assignee.is_empty())
+        .map(|assignee| format!(" @{}", assignee))
+        .unwrap_or_default();
+    format!(
+        "{} [P{}] [{}] {}{} - {}",
+        fmt_show_issue_ref(&v.namespace, &v.id),
+        v.priority,
+        v.issue_type.as_str(),
+        v.status.as_str(),
+        assignee,
+        v.title
+    )
+}
+
+fn render_show_refs(bead: &Issue, incoming: &IncomingGroups, short: bool) -> String {
+    let mut out = String::new();
+    let total = incoming.blocks.len()
+        + incoming.related.len()
+        + incoming.discovered.len()
+        + incoming.children.len();
+
+    if short {
+        if total == 0 {
+            return format!("{} refs=0", fmt_show_issue_ref(&bead.namespace, &bead.id));
+        }
+        for summary in incoming
+            .blocks
+            .iter()
+            .chain(incoming.related.iter())
+            .chain(incoming.discovered.iter())
+            .chain(incoming.children.iter())
+        {
+            out.push_str(&format!(
+                "{} -> {}\n",
+                fmt_show_issue_ref(&summary.namespace, &summary.id),
+                fmt_show_issue_ref(&bead.namespace, &bead.id)
+            ));
+        }
+        return out;
+    }
+
+    out.push_str(&format!(
+        "{} references ({total})\n",
+        fmt_show_issue_ref(&bead.namespace, &bead.id)
+    ));
+    append_summary_group(&mut out, "Blocks", &incoming.blocks, "  <-");
+    append_summary_group(&mut out, "Related", &incoming.related, "  <>");
+    append_summary_group(&mut out, "Discovered From", &incoming.discovered, "  <>");
+    append_summary_group(&mut out, "Children", &incoming.children, "  <-");
+    out
+}
+
+fn render_show_children(bead: &Issue, children: &[IssueSummary], short: bool) -> String {
+    if short {
+        if children.is_empty() {
+            return format!(
+                "{} children=0",
+                fmt_show_issue_ref(&bead.namespace, &bead.id)
+            );
+        }
+        let mut out = String::new();
+        for child in children {
+            out.push_str(&format!(
+                "{} [P{}] [{}] {} - {}\n",
+                fmt_show_issue_ref(&child.namespace, &child.id),
+                child.priority,
+                child.issue_type.as_str(),
+                child.status.as_str(),
+                child.title
+            ));
+        }
+        return out;
+    }
+
+    let mut out = String::new();
+    out.push_str(&format!(
+        "{} children ({})\n",
+        fmt_show_issue_ref(&bead.namespace, &bead.id),
+        children.len()
+    ));
+    if children.is_empty() {
+        out.push_str("  (none)\n");
+        return out;
+    }
+    for child in children {
+        out.push_str(&format!(
+            "  -> {}: {} [P{}] [{}]\n",
+            fmt_show_issue_ref(&child.namespace, &child.id),
+            child.title,
+            child.priority,
+            child.status.as_str()
+        ));
+    }
+    out
+}
+
+fn append_summary_group(out: &mut String, label: &str, summaries: &[IssueSummary], prefix: &str) {
+    if summaries.is_empty() {
+        return;
+    }
+    out.push_str(&format!("\n{label} ({}):\n", summaries.len()));
+    for summary in summaries {
+        out.push_str(&format!(
+            "{prefix} {}: {} [P{}] [{}]\n",
+            fmt_show_issue_ref(&summary.namespace, &summary.id),
+            summary.title,
+            summary.priority,
+            summary.status.as_str()
+        ));
+    }
+}
+
+fn fmt_show_issue_ref(namespace: &NamespaceId, id: &str) -> String {
+    if *namespace == NamespaceId::core() {
+        id.to_string()
+    } else {
+        fmt_issue_ref(namespace, id)
+    }
 }
 
 /// Render epic children with progress breakdown and priority sorting.
@@ -456,7 +659,7 @@ fn render_epic_children(out: &mut String, children: &[IssueSummary]) {
                 " {}[P{}] {}: {}{}\n",
                 status_marker,
                 child.priority,
-                fmt_issue_ref(&child.namespace, &child.id),
+                fmt_show_issue_ref(&child.namespace, &child.id),
                 child.title,
                 assignee
             ));
@@ -468,11 +671,71 @@ fn render_epic_children(out: &mut String, children: &[IssueSummary]) {
         for child in &done {
             out.push_str(&format!(
                 "  [x] {}: {}\n",
-                fmt_issue_ref(&child.namespace, &child.id),
+                fmt_show_issue_ref(&child.namespace, &child.id),
                 child.title
             ));
         }
     }
+}
+
+fn resolve_current_issue_id(ctx: &CliRuntimeCtx) -> CommandResult<BeadId> {
+    if let Some(id) = current_jj_bead_id(&ctx.repo) {
+        return Ok(id);
+    }
+
+    let filters = Filters {
+        assignee: Some(ctx.actor_id()?),
+        status: Some(String::from("in_progress")),
+        sort_by: Some(SortField::UpdatedAt),
+        ascending: false,
+        limit: Some(1),
+        ..Filters::default()
+    };
+    let req = Request::List {
+        ctx: ctx.read_ctx(),
+        payload: ListPayload { filters },
+    };
+    match send(&req)? {
+        ResponsePayload::Query(QueryResult::Issues(mut issues)) => issues
+            .drain(..)
+            .next()
+            .map(|summary| BeadId::parse(&summary.id))
+            .transpose()?
+            .ok_or_else(|| {
+                validation_error(
+                    "current",
+                    "no current bead found (no bead id in the current jj change and no in-progress bead assigned to you)",
+                )
+                .into()
+            }),
+        other => Err(CommandError::Ipc(beads_surface::ipc::IpcError::DaemonUnavailable(
+            format!("unexpected response while resolving current bead: {other:?}"),
+        ))),
+    }
+}
+
+fn current_jj_bead_id(repo: &Path) -> Option<BeadId> {
+    let output = ProcessCommand::new("jj")
+        .current_dir(repo)
+        .args(["log", "-r", "@", "--no-graph", "-T", "description"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let description = String::from_utf8(output.stdout).ok()?;
+    extract_bead_id_from_text(&description)
+}
+
+fn extract_bead_id_from_text(text: &str) -> Option<BeadId> {
+    text.split_whitespace().find_map(|token| {
+        let candidate =
+            token.trim_matches(|ch: char| !ch.is_ascii_alphanumeric() && ch != '-' && ch != '.');
+        if candidate.is_empty() {
+            return None;
+        }
+        normalize_bead_id(candidate).ok()
+    })
 }
 
 #[cfg(test)]
@@ -515,7 +778,30 @@ mod tests {
     }
 
     #[test]
-    fn render_show_includes_namespace() {
+    fn render_show_omits_core_namespace() {
+        let issue = sample_issue("core", "bd-123");
+        let incoming = IncomingGroups {
+            children: Vec::new(),
+            blocks: Vec::new(),
+            related: Vec::new(),
+            discovered: Vec::new(),
+        };
+
+        let output = render_show(&issue, &[], &incoming, &[]);
+        let expected = concat!(
+            "\nbd-123: Title\n",
+            "Status: open\n",
+            "Priority: P1\n",
+            "Type: task\n",
+            "Created: 1970-01-01 00:00\n",
+            "Updated: 1970-01-01 00:00\n",
+            "\n",
+        );
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn render_show_includes_non_core_namespace() {
         let issue = sample_issue("wf", "bd-123");
         let incoming = IncomingGroups {
             children: Vec::new(),
@@ -536,5 +822,48 @@ mod tests {
             "\n",
         );
         assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn resolve_show_ids_accepts_repeated_flag_ids() {
+        let ids = resolve_show_ids(
+            &CliRuntimeCtx {
+                repo: std::path::PathBuf::from("/tmp/beads"),
+                json: false,
+                namespace: None,
+                durability: None,
+                client_request_id: None,
+                require_min_seen: None,
+                wait_timeout_ms: None,
+                actor_id: None,
+            },
+            Vec::new(),
+            vec!["beads-rs-k8u3".to_string(), "beads-rs-k8u3.5".to_string()],
+            false,
+        )
+        .expect("show ids");
+        assert_eq!(ids[0].as_str(), "beads-rs-k8u3");
+        assert_eq!(ids[1].as_str(), "beads-rs-k8u3.5");
+    }
+
+    #[test]
+    fn render_issue_detail_is_compact_for_core_namespace() {
+        let issue = sample_issue("core", "bd-123");
+        let output = render_issue_detail(&issue);
+        assert!(!output.contains("Namespace: core"));
+        assert!(output.contains("\nbd-123: Title\n"));
+    }
+
+    #[test]
+    fn render_issue_summary_is_one_line() {
+        let issue = sample_issue("core", "bd-123");
+        let output = render_issue_summary(&issue);
+        assert_eq!(output, "bd-123 [P1] [task] open - Title");
+    }
+
+    #[test]
+    fn extract_bead_id_from_text_accepts_jj_style_descriptions() {
+        let id = extract_bead_id_from_text("beads-rs-k8u3.5: show affordances").expect("bead id");
+        assert_eq!(id.as_str(), "beads-rs-k8u3.5");
     }
 }

--- a/crates/beads-cli/src/commands/update.rs
+++ b/crates/beads-cli/src/commands/update.rs
@@ -1,10 +1,11 @@
 use clap::Args;
 
 use super::common::fetch_issue;
+use super::input::{FileTextArg, InlineTextArg, resolve_text_input, text_input_uses_stdin};
 use super::{CommandError, CommandResult, print_ok};
 use crate::parsers::{parse_bead_type, parse_priority};
 use crate::render::print_line;
-use crate::runtime::{CliRuntimeCtx, resolve_description, send};
+use crate::runtime::{CliRuntimeCtx, send};
 use crate::validation::{
     normalize_bead_id, normalize_bead_id_for, normalize_dep_specs, validation_error,
 };
@@ -31,16 +32,39 @@ pub struct UpdateArgs {
     #[arg(long)]
     pub title: Option<String>,
 
-    #[arg(short = 'd', long, allow_hyphen_values = true)]
+    /// Replace the description/body text.
+    #[arg(short = 'd', long, alias = "desc", allow_hyphen_values = true)]
     pub description: Option<String>,
 
     /// Alias for --description (GitHub CLI convention).
     #[arg(long = "body", hide = true, allow_hyphen_values = true)]
     pub body: Option<String>,
 
+    /// Alias for --description (git commit convention).
+    #[arg(short = 'm', long = "message", hide = true, allow_hyphen_values = true)]
+    pub message: Option<String>,
+
+    /// Read description from file (use `-` for stdin).
+    #[arg(long = "body-file", value_name = "PATH")]
+    pub body_file: Option<std::path::PathBuf>,
+
+    /// Alias for --body-file.
+    #[arg(long = "description-file", hide = true, value_name = "PATH")]
+    pub description_file: Option<std::path::PathBuf>,
+
+    /// Read description from stdin.
+    #[arg(long)]
+    pub stdin: bool,
+
+    /// Replace the design section.
     #[arg(long, allow_hyphen_values = true)]
     pub design: Option<String>,
 
+    /// Read design text from file (use `-` for stdin).
+    #[arg(long = "design-file", value_name = "PATH")]
+    pub design_file: Option<std::path::PathBuf>,
+
+    /// Replace the acceptance criteria section.
     #[arg(
         long = "acceptance",
         alias = "acceptance-criteria",
@@ -126,10 +150,67 @@ pub fn handle(ctx: &CliRuntimeCtx, mut args: UpdateArgs) -> CommandResult<()> {
     if let Some(title) = args.title {
         patch.title = Patch::Set(title);
     }
-    if let Some(desc) = resolve_description(args.description, args.body)? {
+    let description_sources_inline = [
+        InlineTextArg {
+            flag: "--description",
+            value: args.description.as_deref(),
+        },
+        InlineTextArg {
+            flag: "--body",
+            value: args.body.as_deref(),
+        },
+        InlineTextArg {
+            flag: "--message",
+            value: args.message.as_deref(),
+        },
+    ];
+    let description_sources_files = [
+        FileTextArg {
+            flag: "--body-file",
+            path: args.body_file.as_deref(),
+        },
+        FileTextArg {
+            flag: "--description-file",
+            path: args.description_file.as_deref(),
+        },
+    ];
+    let design_sources_inline = [InlineTextArg {
+        flag: "--design",
+        value: args.design.as_deref(),
+    }];
+    let design_sources_files = [FileTextArg {
+        flag: "--design-file",
+        path: args.design_file.as_deref(),
+    }];
+    if text_input_uses_stdin(
+        &description_sources_inline,
+        &description_sources_files,
+        args.stdin,
+        true,
+    ) && text_input_uses_stdin(&design_sources_inline, &design_sources_files, false, false)
+    {
+        return Err(validation_error(
+            "stdin",
+            "description and design cannot both read from stdin in the same invocation; use a file for one of them",
+        )
+        .into());
+    }
+    if let Some(desc) = resolve_text_input(
+        "description",
+        &description_sources_inline,
+        &description_sources_files,
+        args.stdin,
+        true,
+    )? {
         patch.description = Patch::Set(desc);
     }
-    if let Some(design) = args.design {
+    if let Some(design) = resolve_text_input(
+        "design",
+        &design_sources_inline,
+        &design_sources_files,
+        false,
+        false,
+    )? {
         patch.design = Patch::Set(design);
     }
     if let Some(acc) = args.acceptance {
@@ -337,4 +418,64 @@ fn parse_status(raw: &str) -> CommandResult<WorkflowStatus> {
 
 fn parse_status_arg(raw: &str) -> std::result::Result<String, String> {
     Ok(crate::parsers::parse_status(raw))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::CommandError;
+    use beads_core::NamespaceId;
+
+    fn sample_ctx() -> CliRuntimeCtx {
+        CliRuntimeCtx {
+            repo: std::path::PathBuf::from("/tmp/beads"),
+            json: false,
+            namespace: Some(NamespaceId::core()),
+            durability: None,
+            client_request_id: None,
+            require_min_seen: None,
+            wait_timeout_ms: None,
+            actor_id: None,
+        }
+    }
+
+    #[test]
+    fn update_rejects_double_stdin_usage() {
+        let err = handle(
+            &sample_ctx(),
+            UpdateArgs {
+                id: "beads-rs-k8u3".to_string(),
+                parent: None,
+                no_parent: false,
+                title: None,
+                description: None,
+                body: None,
+                message: None,
+                body_file: None,
+                description_file: None,
+                stdin: true,
+                design: None,
+                design_file: Some(std::path::PathBuf::from("-")),
+                acceptance: None,
+                external_ref: None,
+                estimate: None,
+                status: None,
+                reason: None,
+                priority: None,
+                bead_type: None,
+                assignee: None,
+                add_label: Vec::new(),
+                remove_label: Vec::new(),
+                notes: None,
+                deps: Vec::new(),
+            },
+        )
+        .expect_err("double stdin usage must fail");
+
+        assert!(matches!(err, CommandError::Validation(_)));
+        assert!(
+            err.to_string()
+                .contains("description and design cannot both read from stdin")
+        );
+    }
 }

--- a/crates/beads-cli/src/runtime.rs
+++ b/crates/beads-cli/src/runtime.rs
@@ -116,28 +116,6 @@ impl CliRuntimeCtx {
     }
 }
 
-pub fn resolve_description(
-    description: Option<String>,
-    body: Option<String>,
-) -> ValidationResult<Option<String>> {
-    match (description, body) {
-        (Some(d), Some(b)) => {
-            if d != b {
-                return Err(validation::validation_error(
-                    "description",
-                    format!(
-                        "cannot specify both --description and --body with different values (--description={d:?}, --body={b:?})"
-                    ),
-                ));
-            }
-            Ok(Some(d))
-        }
-        (Some(d), None) => Ok(Some(d)),
-        (None, Some(b)) => Ok(Some(b)),
-        (None, None) => Ok(None),
-    }
-}
-
 pub fn validate_actor_id(raw: &str) -> ValidationResult<ActorId> {
     ValidatedActorId::parse(raw)
         .map(Into::into)
@@ -205,18 +183,6 @@ mod tests {
     use beads_surface::ipc::ResponsePayload;
     use serde_json::json;
     use uuid::Uuid;
-
-    #[test]
-    fn resolve_description_rejects_mismatched_alias_values() {
-        let err = resolve_description(Some("a".into()), Some("b".into())).expect_err("conflict");
-        assert_eq!(
-            err,
-            validation::validation_error(
-                "description",
-                "cannot specify both --description and --body with different values (--description=\"a\", --body=\"b\")"
-            )
-        );
-    }
 
     #[test]
     fn mutation_meta_includes_actor_override() {

--- a/crates/beads-rs/tests/integration/daemon/crash_recovery.rs
+++ b/crates/beads-rs/tests/integration/daemon/crash_recovery.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 use crate::fixtures::bd_runtime::{
     store_dir_from_data_dir, store_meta_from_data_dir, wait_for_daemon_pid, wait_for_store_id,
 };
+use crate::fixtures::ipc_client::runtime_bound_client_no_autostart;
 use crate::fixtures::realtime::RealtimeFixture;
 use crate::fixtures::store_lock::unlock_store;
 use crate::fixtures::wait;
@@ -17,7 +18,7 @@ use beads_api::QueryResult;
 use beads_core::{BeadId, BeadType, EventId, NamespaceId, Priority, Seq1};
 use beads_daemon::testkit::wal::{IndexDurabilityMode, SqliteWalIndex, WalIndex};
 use beads_surface::ipc::{
-    CreatePayload, IpcClient, MutationCtx, MutationMeta, Request, Response, ResponsePayload,
+    CreatePayload, MutationCtx, MutationMeta, Request, Response, ResponsePayload,
 };
 
 fn marker_path(dir: &Path, stage: &str) -> PathBuf {
@@ -110,7 +111,7 @@ fn crash_recovery_truncates_tail_and_resets_origin_seq() {
     start_daemon_with_hang(&fixture, "wal_after_write", &hang_dir);
 
     let request = create_request(fixture.repo_path(), "bd-crash-tail", "crash tail");
-    let client = IpcClient::for_runtime_dir(fixture.runtime_dir()).with_autostart(false);
+    let client = runtime_bound_client_no_autostart(fixture.runtime_dir());
     let handle = thread::spawn(move || client.send_request(&request));
 
     let marker = marker_path(&hang_dir, "wal_after_write");
@@ -148,7 +149,7 @@ fn crash_recovery_truncates_tail_and_resets_origin_seq() {
         "expected tail truncation to shrink segment"
     );
 
-    let client = IpcClient::for_runtime_dir(fixture.runtime_dir()).with_autostart(false);
+    let client = runtime_bound_client_no_autostart(fixture.runtime_dir());
     let create_resp = client
         .send_request(&create_request(
             fixture.repo_path(),
@@ -179,7 +180,7 @@ fn crash_recovery_rebuilds_index_after_fsync_before_commit() {
     start_daemon_with_hang(&fixture, "wal_mutation_before_atomic_commit", &hang_dir);
 
     let request = create_request(fixture.repo_path(), "bd-crash-index", "crash index");
-    let client = IpcClient::for_runtime_dir(fixture.runtime_dir()).with_autostart(false);
+    let client = runtime_bound_client_no_autostart(fixture.runtime_dir());
     let handle = thread::spawn(move || client.send_request(&request));
 
     let marker = marker_path(&hang_dir, "wal_mutation_before_atomic_commit");

--- a/crates/beads-rs/tests/integration/daemon/repl_e2e.rs
+++ b/crates/beads-rs/tests/integration/daemon/repl_e2e.rs
@@ -10,6 +10,7 @@ use std::num::NonZeroU32;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
+use crate::fixtures::ipc_client::runtime_bound_client_no_autostart;
 use crate::fixtures::receipt;
 use crate::fixtures::repl_rig::{
     DurabilityEligibility, FaultProfile, ReplRig, ReplRigOptions, TailnetTraceConfig,
@@ -25,8 +26,8 @@ use beads_core::{
     ReplicaDurabilityRole, ReplicaEntry, Seq0,
 };
 use beads_surface::ipc::{
-    AdminCheckpointWaitPayload, AdminOp, CreatePayload, IdPayload, IpcClient, MutationCtx,
-    MutationMeta, ReadConsistency, ReadCtx, RepoCtx, Request, Response, ResponsePayload,
+    AdminCheckpointWaitPayload, AdminOp, CreatePayload, IdPayload, MutationCtx, MutationMeta,
+    ReadConsistency, ReadCtx, RepoCtx, Request, Response, ResponsePayload,
 };
 use beads_surface::ops::OpResult;
 
@@ -117,7 +118,7 @@ fn wait_for_checkpoint(rig: &ReplRig, idx: usize, namespace: &NamespaceId, timeo
 
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
-        let client = IpcClient::for_runtime_dir(&runtime_dir).with_autostart(false);
+        let client = runtime_bound_client_no_autostart(&runtime_dir);
         let request = Request::Admin(AdminOp::CheckpointWait {
             ctx: RepoCtx::new(repo_dir),
             payload: AdminCheckpointWaitPayload {
@@ -670,7 +671,7 @@ fn create_issue_with_durability_result(
     k: NonZeroU32,
 ) -> Response {
     let node = rig.node(node_idx);
-    let client = IpcClient::for_runtime_dir(node.runtime_dir()).with_autostart(false);
+    let client = runtime_bound_client_no_autostart(node.runtime_dir());
     let request = Request::Create {
         ctx: MutationCtx::new(
             node.repo_dir().to_path_buf(),
@@ -705,7 +706,7 @@ fn show_issue_with_read(
     read: ReadConsistency,
 ) -> Response {
     let node = rig.node(node_idx);
-    let client = IpcClient::for_runtime_dir(node.runtime_dir()).with_autostart(false);
+    let client = runtime_bound_client_no_autostart(node.runtime_dir());
     let request = Request::Show {
         ctx: ReadCtx::new(node.repo_dir().to_path_buf(), read),
         payload: IdPayload {

--- a/crates/beads-rs/tests/integration/fixtures/AGENTS.md
+++ b/crates/beads-rs/tests/integration/fixtures/AGENTS.md
@@ -8,7 +8,7 @@ NEVER: hide owner-crate logic or one-off test behavior here. If a helper stops b
 - Use `temp.rs` for short deterministic temp roots, owner metadata, stale fixture cleanup, and Unix socket path checks. Do not derive temp paths from `current_dir()/tmp`.
 - Use `wait.rs` for polling and child lifecycle. `wait_for_child_exit()` and `kill_child_and_wait()` reap `Child`s; bare `kill()` and PID-only checks leak processes.
 - Use `daemon_runtime.rs` when a fixture owns daemon shutdown/crash semantics. Pass the owning fixture's `runtime_dir` and `data_dir`; do not assume `data/` lives under the runtime tree.
-- Owned daemons should be driven through `IpcClient::for_runtime_dir(...).with_autostart(false)` so autostart helpers do not steal lifecycle ownership.
+- Owned daemons should be driven through the shared helpers in `ipc_client.rs` so assembly tests share one runtime-bound `IpcClient` construction path while keeping autostart disabled for fixture-owned daemons.
 - Use `realtime.rs` or `BdRuntimeRepo` for single-daemon tests. Reach for `repl_rig.rs` only when you truly need multi-daemon replication, peer config churn, or tailnet proxy faults.
 - Use `admin_status.rs` when you need repeated admin-status sampling under load instead of open-coding status collectors in individual tests. Bind those helpers to the owning runtime dir; do not introduce ambient `IpcClient::new()` shortcuts there or in `ipc_stream.rs` / `load_gen.rs`.
 - `tailnet_proxy.rs` is the external fault-injection harness consumed by `repl_rig.rs` and `daemon/repl_e2e.rs`; keep those surfaces aligned.

--- a/crates/beads-rs/tests/integration/fixtures/admin_status.rs
+++ b/crates/beads-rs/tests/integration/fixtures/admin_status.rs
@@ -15,6 +15,8 @@ use beads_surface::ipc::{
     Response, ResponsePayload,
 };
 
+use super::ipc_client::runtime_bound_client;
+
 #[derive(Debug, Error)]
 pub enum StatusError {
     #[error(transparent)]
@@ -38,7 +40,7 @@ pub struct StatusCollector {
 
 impl StatusCollector {
     pub fn for_runtime_dir(repo: PathBuf, runtime_dir: &Path) -> Self {
-        Self::with_client(repo, IpcClient::for_runtime_dir(runtime_dir))
+        Self::with_client(repo, runtime_bound_client(runtime_dir))
     }
 
     pub fn with_client(repo: PathBuf, client: IpcClient) -> Self {

--- a/crates/beads-rs/tests/integration/fixtures/bd_runtime.rs
+++ b/crates/beads-rs/tests/integration/fixtures/bd_runtime.rs
@@ -13,6 +13,7 @@ use tempfile::TempDir;
 
 use super::daemon_runtime::shutdown_daemon;
 use super::git::{init_bare_repo, init_repo, init_repo_with_origin};
+use super::ipc_client::{runtime_bound_client, runtime_bound_client_no_autostart};
 use super::temp;
 use super::timing;
 use super::wait;
@@ -450,12 +451,12 @@ impl BdRuntimeRepo {
     }
 
     pub fn ipc_client_no_autostart(&self) -> IpcClient {
-        IpcClient::for_runtime_dir(self.runtime_dir()).with_autostart(false)
+        runtime_bound_client_no_autostart(self.runtime_dir())
     }
 
     #[allow(dead_code)]
     pub fn ipc_client_autostart(&self) -> IpcClient {
-        IpcClient::for_runtime_dir(self.runtime_dir())
+        runtime_bound_client(self.runtime_dir())
     }
 
     pub fn bd_with_profile(&self, profile: BdCommandProfile) -> Command {

--- a/crates/beads-rs/tests/integration/fixtures/daemon_runtime.rs
+++ b/crates/beads-rs/tests/integration/fixtures/daemon_runtime.rs
@@ -295,7 +295,6 @@ mod tests {
     use std::time::Duration;
 
     use beads_daemon::test_utils::daemon_meta_path;
-    use beads_surface::ipc::IpcClient;
 
     use crate::fixtures::bd_runtime::{
         BdCommandProfile, spawn_daemon_with_paths, wait_for_daemon_ready,
@@ -370,7 +369,7 @@ mod tests {
             BdCommandProfile::daemon(),
         );
         let pid = child.id();
-        let client = IpcClient::for_runtime_dir(&runtime_dir).with_autostart(false);
+        let client = crate::fixtures::ipc_client::runtime_bound_client_no_autostart(&runtime_dir);
         assert!(
             wait_for_daemon_ready(&client, Duration::from_secs(5)),
             "daemon should become ready"

--- a/crates/beads-rs/tests/integration/fixtures/ipc_client.rs
+++ b/crates/beads-rs/tests/integration/fixtures/ipc_client.rs
@@ -1,0 +1,10 @@
+use beads_surface::ipc::IpcClient;
+use std::path::Path;
+
+pub fn runtime_bound_client(runtime_dir: &Path) -> IpcClient {
+    IpcClient::for_runtime_dir(runtime_dir)
+}
+
+pub fn runtime_bound_client_no_autostart(runtime_dir: &Path) -> IpcClient {
+    runtime_bound_client(runtime_dir).with_autostart(false)
+}

--- a/crates/beads-rs/tests/integration/fixtures/ipc_stream.rs
+++ b/crates/beads-rs/tests/integration/fixtures/ipc_stream.rs
@@ -12,6 +12,8 @@ use beads_surface::ipc::{
     ResponsePayload, SubscriptionStream,
 };
 
+use super::ipc_client::runtime_bound_client;
+
 #[derive(Debug)]
 pub enum StreamMessage {
     Subscribed(SubscribeInfo),
@@ -131,10 +133,6 @@ impl StreamingClient {
             Response::Err { err } => Err(StreamClientError::Remote(Box::new(err))),
         }
     }
-}
-
-fn runtime_bound_client(runtime_dir: &Path) -> IpcClient {
-    IpcClient::for_runtime_dir(runtime_dir)
 }
 
 #[cfg(test)]

--- a/crates/beads-rs/tests/integration/fixtures/load_gen.rs
+++ b/crates/beads-rs/tests/integration/fixtures/load_gen.rs
@@ -13,6 +13,7 @@ use beads_surface::ipc::{
     CreatePayload, IpcClient, IpcError, MutationCtx, MutationMeta, Request, Response,
 };
 
+use super::ipc_client::runtime_bound_client;
 use super::timing;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -70,7 +71,7 @@ pub struct LoadGenerator {
 
 impl LoadGenerator {
     pub fn for_runtime_dir(repo: PathBuf, runtime_dir: &Path) -> Self {
-        Self::with_client(repo, IpcClient::for_runtime_dir(runtime_dir))
+        Self::with_client(repo, runtime_bound_client(runtime_dir))
     }
 
     pub fn with_client(repo: PathBuf, client: IpcClient) -> Self {

--- a/crates/beads-rs/tests/integration/fixtures/mod.rs
+++ b/crates/beads-rs/tests/integration/fixtures/mod.rs
@@ -13,6 +13,7 @@ pub mod daemon_runtime;
 pub mod event_body;
 pub mod git;
 pub mod identity;
+pub mod ipc_client;
 pub mod ipc_stream;
 pub mod legacy_store;
 pub mod load_gen;

--- a/crates/beads-rs/tests/integration/fixtures/repl_rig.rs
+++ b/crates/beads-rs/tests/integration/fixtures/repl_rig.rs
@@ -22,9 +22,9 @@ use beads_core::{
 };
 use beads_rs::config::{Config, ReplicationPeerConfig};
 use beads_surface::ipc::{
-    AdminFingerprintPayload, AdminOp, CreatePayload, EmptyPayload, IdPayload, IpcClient,
-    IpcConnection, IpcError, MutationCtx, MutationMeta, ReadConsistency, ReadCtx, RepoCtx, Request,
-    Response, ResponsePayload,
+    AdminFingerprintPayload, AdminOp, CreatePayload, EmptyPayload, IdPayload, IpcConnection,
+    IpcError, MutationCtx, MutationMeta, ReadConsistency, ReadCtx, RepoCtx, Request, Response,
+    ResponsePayload,
 };
 use beads_surface::ops::OpResult;
 
@@ -35,6 +35,7 @@ use super::bd_runtime::{
 use super::daemon_boundary::wal::{SEGMENT_HEADER_PREFIX_LEN, SegmentHeader};
 use super::daemon_runtime::{crash_daemon, shutdown_daemon};
 use super::git::{init_bare_repo, init_repo_with_origin};
+use super::ipc_client::runtime_bound_client_no_autostart;
 use super::tailnet_proxy::{TailnetProfile, TailnetProxy, TailnetTrace, TailnetTraceMode};
 use super::temp;
 use super::timing;
@@ -1298,7 +1299,7 @@ impl Node {
         self.retry_ipc_send(request, || {
             let mut guard = conn_slot.lock().expect("ipc conn lock");
             if guard.is_none() {
-                let client = IpcClient::for_runtime_dir(&self.runtime_dir).with_autostart(false);
+                let client = runtime_bound_client_no_autostart(&self.runtime_dir);
                 *guard = Some(client.connect()?);
             }
             let conn = guard.as_mut().expect("ipc conn");
@@ -1311,7 +1312,7 @@ impl Node {
     fn send_with_fresh_connection(&self, request: &Request) -> Result<Response, IpcError> {
         let timeout = ipc_timeout_for_request(request);
         self.retry_ipc_send(request, || {
-            let client = IpcClient::for_runtime_dir(&self.runtime_dir).with_autostart(false);
+            let client = runtime_bound_client_no_autostart(&self.runtime_dir);
             let mut conn = client.connect()?;
             conn.set_read_timeout(Some(timeout))?;
             conn.set_write_timeout(Some(timeout))?;
@@ -1367,7 +1368,7 @@ fn bootstrap_replica(
         &node.config_dir,
         store_id_override,
     );
-    let client = IpcClient::for_runtime_dir(&node.runtime_dir).with_autostart(false);
+    let client = runtime_bound_client_no_autostart(&node.runtime_dir);
     assert!(
         wait_for_daemon_ready(&client, Duration::from_secs(5)),
         "daemon failed to start for {}",


### PR DESCRIPTION
## Summary
- add a grouped root help surface and improve command help/alias discoverability across bd
- port higher-value CLI UX from beads-go across create, update, dep, show, list, prime, and setup
- centralize assembly IPC fixture client construction while keeping the rebased branch on the mainline IPC protocol surface

## Verification
- cargo fmt --all
- cargo check -p beads-cli -p beads-surface -p beads-rs
- cargo xtest
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/delightful-ai/beads-rs/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CLI parsing/output across several core commands (`create`, `update`, `show`, `list`, `prime`, `setup`) and adds new stdin/file input paths and recursive tree listing, which could affect existing scripts and edge-case behavior.
> 
> **Overview**
> **CLI UX/help overhaul.** Adds richer `clap` metadata (visible aliases, long descriptions, and example blocks) for key commands and updates `prime`/`setup`/`dep` help discoverability.
> 
> **More flexible input/output.** `create`/`update` now accept `--desc`, hidden `--message`, `--body-file`/`--design-file`, and `--stdin` via a new shared `commands::input` resolver with conflict validation (including rejecting dual-stdin usage). `list` gains `--all` (defaults to open in human mode), `--long`, and `--tree` (recursive child tree requiring `--parent`). `show` is extended to support multiple ids, `--current` (jj-based or latest in-progress), `--short`, `--refs`, and `--children`, plus more compact core-namespace rendering.
> 
> **Prime/setup improvements + test harness cleanup.** `prime` becomes argument-driven with full vs MCP modes, `--stealth`, override file support (`.beads/PRIME.md` or global config), and automatic MCP detection from editor markers/Claude settings. `setup` adds `list` and new file-based recipes (Codex/Gemini/OpenCode/Windsurf) alongside Cursor/Aider refactoring, and integration tests centralize runtime-bound `IpcClient` construction via a shared fixture helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e64495908cc0ce16561f408db007d9956950782. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->